### PR TITLE
RD-3150 - code - optimization of the reporting process

### DIFF
--- a/src/lumigo_tracer/spans_container.py
+++ b/src/lumigo_tracer/spans_container.py
@@ -74,6 +74,7 @@ class SpansContainer:
             "info": {"tracer": {"version": version}, "traceId": {"Root": trace_root}},
             "event": event,
             "envs": envs,
+            "token": Configuration.token,
         }
         self.function_span = recursive_json_join(
             {

--- a/src/lumigo_tracer/utils.py
+++ b/src/lumigo_tracer/utils.py
@@ -17,9 +17,8 @@ LOG_FORMAT = "#LUMIGO# - %(asctime)s - %(levelname)s - %(message)s"
 SECONDS_TO_TIMEOUT = 0.5
 LUMIGO_EVENT_KEY = "_lumigo"
 STEP_FUNCTION_UID_KEY = "step_function_uid"
-TOO_BIG_SPANS_THRESHOLD = (
-    5
-)  # number of spans that are too big to enter the reported message before break
+# number of spans that are too big to enter the reported message before break
+TOO_BIG_SPANS_THRESHOLD = 5
 MAX_SIZE_FOR_REQUEST: int = int(os.environ.get("LUMIGO_MAX_SIZE_FOR_REQUEST", 900_000))
 MAX_VARS_SIZE = 100_000
 MAX_VAR_LEN = 200
@@ -47,7 +46,6 @@ LUMIGO_SECRET_MASKING_REGEX = "LUMIGO_SECRET_MASKING_REGEX"
 WARN_CLIENT_PREFIX = "Lumigo Warning"
 TIMEOUT_TIMER_BUFFER = 0.7
 NUMBER_OF_SPANS_IN_REPORT_OPTIMIZATION = 200
-
 
 _logger: Union[logging.Logger, None] = None
 
@@ -179,7 +177,7 @@ def report_json(region: Union[None, str], msgs: List[dict]) -> int:
     :return: The duration of reporting (in milliseconds),
                 or 0 if we didn't send (due to configuration or fail).
     """
-    get_logger().info(f"reporting the messages: {msgs[:10]}...")
+    get_logger().info(f"reporting the messages: {msgs[:10]}")
     host = Configuration.host or EDGE_HOST.format(region=region)
     duration = 0
     if Configuration.should_report:
@@ -329,7 +327,7 @@ def omit_keys(value: Any, regexes: Optional[List] = None):
         return [omit_keys(item, regexes) for item in value]
     if isinstance(value, (str, bytes)):
         try:
-            # This is an optimization step. Fast identify if it's a dict
+            # This is an optimization step. Fast identify if this is a dict
             if value.startswith("{") if isinstance(value, str) else value.startswith(b"{"):
                 parsed_value = json.loads(value)
                 if isinstance(parsed_value, dict):

--- a/src/lumigo_tracer/utils.py
+++ b/src/lumigo_tracer/utils.py
@@ -17,7 +17,9 @@ LOG_FORMAT = "#LUMIGO# - %(asctime)s - %(levelname)s - %(message)s"
 SECONDS_TO_TIMEOUT = 0.5
 LUMIGO_EVENT_KEY = "_lumigo"
 STEP_FUNCTION_UID_KEY = "step_function_uid"
-MIN_SPAN_SIZE = 300
+TOO_BIG_SPANS_THRESHOLD = (
+    5
+)  # number of spans that are too big to enter the reported message before break
 MAX_SIZE_FOR_REQUEST: int = int(os.environ.get("LUMIGO_MAX_SIZE_FOR_REQUEST", 900_000))
 MAX_VARS_SIZE = 100_000
 MAX_VAR_LEN = 200
@@ -44,6 +46,8 @@ LUMIGO_SECRET_MASKING_REGEX_BACKWARD_COMP = "LUMIGO_BLACKLIST_REGEX"
 LUMIGO_SECRET_MASKING_REGEX = "LUMIGO_SECRET_MASKING_REGEX"
 WARN_CLIENT_PREFIX = "Lumigo Warning"
 TIMEOUT_TIMER_BUFFER = 0.7
+NUMBER_OF_SPANS_IN_REPORT_OPTIMIZATION = 200
+
 
 _logger: Union[logging.Logger, None] = None
 
@@ -138,22 +142,30 @@ def _create_request_body(
     msgs: List[dict],
     prune_size_flag: bool,
     max_size: int = MAX_SIZE_FOR_REQUEST,
-    min_size: int = MIN_SPAN_SIZE,
+    too_big_spans_threshold: int = TOO_BIG_SPANS_THRESHOLD,
 ) -> str:
-    if not prune_size_flag or _get_event_base64_size(msgs) < max_size:
+
+    if not prune_size_flag or (
+        len(msgs) < NUMBER_OF_SPANS_IN_REPORT_OPTIMIZATION
+        and _get_event_base64_size(msgs) < max_size  # noqa
+    ):
         return json.dumps(omit_keys(msgs))
 
     end_span = msgs[-1]
     ordered_spans = sorted(msgs[:-1], key=_is_span_has_error, reverse=True)
 
     spans_to_send: list = [end_span]
-    current_size = 0
+    current_size = _get_event_base64_size(end_span)
+    too_big_spans = 0
     for span in ordered_spans:
         span_size = _get_event_base64_size(span)
         if current_size + span_size < max_size:
             spans_to_send.append(span)
             current_size += span_size
-            if current_size + min_size > max_size:
+        else:
+            # This is an optimization step. If the spans are too big, don't try to send them.
+            too_big_spans += 1
+            if too_big_spans == too_big_spans_threshold:
                 break
     return json.dumps(omit_keys(spans_to_send))
 
@@ -167,9 +179,7 @@ def report_json(region: Union[None, str], msgs: List[dict]) -> int:
     :return: The duration of reporting (in milliseconds),
                 or 0 if we didn't send (due to configuration or fail).
     """
-    for msg in msgs:
-        msg["token"] = Configuration.token
-    get_logger().info(f"reporting the messages: {msgs}")
+    get_logger().info(f"reporting the messages: {msgs[:10]}...")
     host = Configuration.host or EDGE_HOST.format(region=region)
     duration = 0
     if Configuration.should_report:
@@ -319,9 +329,11 @@ def omit_keys(value: Any, regexes: Optional[List] = None):
         return [omit_keys(item, regexes) for item in value]
     if isinstance(value, (str, bytes)):
         try:
-            parsed_value = json.loads(value)
-            if isinstance(parsed_value, dict):
-                return json.dumps(omit_keys(parsed_value, regexes))
+            # This is an optimization step. Fast identify if it's a dict
+            if value.startswith("{") if isinstance(value, str) else value.startswith(b"{"):
+                parsed_value = json.loads(value)
+                if isinstance(parsed_value, dict):
+                    return json.dumps(omit_keys(parsed_value, regexes))
             return value
         except Exception:
             return value

--- a/src/test/unit/test_main_utils.py
+++ b/src/test/unit/test_main_utils.py
@@ -61,10 +61,12 @@ def test_create_request_body_not_effecting_small_events(dummy_span):
     assert _create_request_body([dummy_span], True, 1_000_000) == json.dumps([dummy_span])
 
 
-def test_create_request_body_keep_function_span(dummy_span, function_end_span):
+def test_create_request_body_keep_function_span_and_filter_other_spans(
+    dummy_span, function_end_span
+):
     expected_result = [dummy_span, dummy_span, dummy_span, function_end_span]
     size = _get_event_base64_size(expected_result)
-    assert _create_request_body(expected_result * 2, True, size, 50) == json.dumps(
+    assert _create_request_body(expected_result * 2, True, size) == json.dumps(
         [function_end_span, dummy_span, dummy_span, dummy_span]
     )
 
@@ -81,7 +83,7 @@ def test_create_request_body_take_error_first(dummy_span, error_span, function_e
         function_end_span,
     ]
     size = _get_event_base64_size(expected_result)
-    assert _create_request_body(input, True, size, 50) == json.dumps(expected_result)
+    assert _create_request_body(input, True, size) == json.dumps(expected_result)
 
 
 @pytest.mark.parametrize(

--- a/src/test/unit/test_main_utils.py
+++ b/src/test/unit/test_main_utils.py
@@ -1,4 +1,6 @@
 import inspect
+from decimal import Decimal
+
 import pytest
 from lumigo_tracer.utils import (
     _create_request_body,
@@ -208,6 +210,7 @@ def test_format_frames__check_all_keys_and_values():
         ({"a": set()}, "{'a': set()}"),  # type: ignore
         (b"a", "a"),  # bytes that can be decoded.
         (b"\xff\xfea\x00", "b'\\xff\\xfea\\x00'"),  # bytes that can't be decoded.
+        ({1: Decimal(1)}, '{"1": 1.0}'),  # decimal should be serializeable
     ],
 )
 def test_prepare_large_data(value, output):


### PR DESCRIPTION
On lambda with 256MB that executes 3000 ddb `get_item` requests, reducing the reporting time by 58%. 
Moreover, this puts an upper bound to the duration of the final report, which decreases as the memory of the lambda increases.