### PR TITLE
RD-3150 - faster http hooks

### DIFF
--- a/src/lumigo_tracer/parsers/http_data_classes.py
+++ b/src/lumigo_tracer/parsers/http_data_classes.py
@@ -1,20 +1,18 @@
-from http import client
 from copy import deepcopy
-from typing import Optional
 
 
 class HttpRequest:
     host: str
     method: str
     uri: str
-    headers: Optional[client.HTTPMessage]
+    headers: dict
     body: bytes
 
     def __init__(self, **kwargs):
         self.host = kwargs["host"]
         self.method = kwargs["method"]
         self.uri = kwargs["uri"]
-        self.headers = kwargs.get("headers")
+        self.headers = {k.lower(): v for k, v in (kwargs.get("headers") or {}).items()}
         self.body = kwargs.get("body")
 
     def clone(self, **kwargs):

--- a/src/lumigo_tracer/parsers/utils.py
+++ b/src/lumigo_tracer/parsers/utils.py
@@ -136,8 +136,10 @@ def recursive_json_join(d1: dict, d2: dict):
     * if key in d2 and is not dictionary, then the value is d2[key]
     * otherwise, join d1[key] and d2[key]
     """
+    if d1 is None or d2 is None:
+        return d1 or d2
     d = {}
-    for key in itertools.chain(d1.keys(), d2.keys()):
+    for key in set(itertools.chain(d1.keys(), d2.keys())):
         value = d1.get(key, d2.get(key))
         if isinstance(value, dict):
             d[key] = recursive_json_join(d1.get(key, {}), d2.get(key, {}))
@@ -293,7 +295,7 @@ def _parse_streams(event: dict) -> Dict[str, str]:
 def should_scrub_domain(url: str) -> bool:
     if url and Configuration.domains_scrubber:
         for regex in Configuration.domains_scrubber:
-            if re.match(regex, url, re.IGNORECASE):
+            if regex.match(url):
                 return True
     return False
 

--- a/src/lumigo_tracer/spans_container.py
+++ b/src/lumigo_tracer/spans_container.py
@@ -182,7 +182,7 @@ class SpansContainer:
             else:
                 self.previous_response_body = b""
 
-            headers = {k.lower(): v for k, v in headers.items()}
+            headers = {k.lower(): v for k, v in headers.items()} if headers else {}
             parser = get_parser(host, headers)()  # type: ignore
             if len(self.previous_response_body) < MAX_ENTRY_SIZE:
                 self.previous_response_body += body

--- a/src/lumigo_tracer/spans_container.py
+++ b/src/lumigo_tracer/spans_container.py
@@ -4,7 +4,6 @@ import time
 import uuid
 import signal
 import traceback
-import http.client
 from typing import List, Dict, Tuple, Optional, Callable, Set
 
 from lumigo_tracer.parsers.event_parser import EventParser
@@ -93,7 +92,7 @@ class SpansContainer:
             },
             self.base_msg,
         )
-        self.previous_request: Tuple[Optional[http.client.HTTPMessage], bytes] = (None, b"")
+        self.previous_request: Tuple[Optional[dict], bytes] = (None, b"")
         self.previous_response_body: bytes = b""
         self.http_span_ids_to_send: Set[str] = set()
         self.http_spans: List[Dict] = []
@@ -169,7 +168,7 @@ class SpansContainer:
             self.http_spans[-1]["ended"] = int(time.time() * 1000)
 
     def update_event_response(
-        self, host: Optional[str], status_code: int, headers: http.client.HTTPMessage, body: bytes
+        self, host: Optional[str], status_code: int, headers: dict, body: bytes
     ) -> None:
         """
         :param host: If None, use the host from the last span, otherwise this is the first chuck and we can empty

--- a/src/lumigo_tracer/spans_container.py
+++ b/src/lumigo_tracer/spans_container.py
@@ -182,6 +182,7 @@ class SpansContainer:
             else:
                 self.previous_response_body = b""
 
+            headers = {k.lower(): v for k, v in headers.items()}
             parser = get_parser(host, headers)()  # type: ignore
             if len(self.previous_response_body) < MAX_ENTRY_SIZE:
                 self.previous_response_body += body

--- a/src/lumigo_tracer/sync_http/sync_hook.py
+++ b/src/lumigo_tracer/sync_http/sync_hook.py
@@ -27,6 +27,7 @@ _KILL_SWITCH = "LUMIGO_SWITCH_OFF"
 CONTEXT_WRAPPED_BY_LUMIGO_KEY = "_wrapped_by_lumigo"
 MAX_READ_SIZE = 1024
 already_wrapped = False
+LUMIGO_HEADERS_HOOK_KEY = "_lumigo_headers_hook"
 
 
 def _request_wrapper(func, instance, args, kwargs):
@@ -51,7 +52,12 @@ def _request_wrapper(func, instance, args, kwargs):
     with lumigo_safe_execute("parse request"):
         if isinstance(data, bytes) and _BODY_HEADER_SPLITTER in data:
             headers, body = data.split(_BODY_HEADER_SPLITTER, 1)
-            if _FLAGS_HEADER_SPLITTER in headers:
+            hooked_headers = getattr(instance, LUMIGO_HEADERS_HOOK_KEY, None)
+            if hooked_headers:
+                # we will get here only if _headers_reminder_wrapper ran first. remove its traces.
+                headers = dict(hooked_headers.items())
+                setattr(instance, LUMIGO_HEADERS_HOOK_KEY, None)
+            elif _FLAGS_HEADER_SPLITTER in headers:
                 request_info, headers = headers.split(_FLAGS_HEADER_SPLITTER, 1)
                 headers = http.client.parse_headers(BytesIO(headers))
                 path_and_query_params = (
@@ -63,6 +69,8 @@ def _request_wrapper(func, instance, args, kwargs):
                 )
                 uri = f"{host}{path_and_query_params}"
                 host = host or headers.get("Host")
+            else:
+                headers = None
 
     with lumigo_safe_execute("add request event"):
         if headers:
@@ -80,6 +88,15 @@ def _request_wrapper(func, instance, args, kwargs):
     return ret_val
 
 
+def _headers_reminder_wrapper(func, instance, args, kwargs):
+    """
+    This is the wrapper of the function `http.client.HTTPConnection.request` that gets the headers.
+    Remember the headers helps us to improve performances on requests that use this flow.
+    """
+    setattr(instance, LUMIGO_HEADERS_HOOK_KEY, kwargs.get("headers"))
+    return func(*args, **kwargs)
+
+
 def _response_wrapper(func, instance, args, kwargs):
     """
     This is the wrapper of the function that can be called only after that the http request was sent.
@@ -87,7 +104,7 @@ def _response_wrapper(func, instance, args, kwargs):
     """
     ret_val = func(*args, **kwargs)
     with lumigo_safe_execute("parse response"):
-        headers = ret_val.headers
+        headers = dict(ret_val.headers.items())
         status_code = ret_val.code
         SpansContainer.get_span().update_event_response(instance.host, status_code, headers, b"")
     return ret_val
@@ -101,7 +118,7 @@ def _read_wrapper(func, instance, args, kwargs):
     if ret_val:
         with lumigo_safe_execute("parse response.read"):
             SpansContainer.get_span().update_event_response(
-                None, instance.code, instance.headers, ret_val
+                None, instance.code, dict(instance.headers.items()), ret_val
             )
     return ret_val
 
@@ -115,7 +132,7 @@ def _read_stream_wrapper_generator(stream_generator, instance):
     for partial_response in stream_generator:
         with lumigo_safe_execute("parse response.read_chunked"):
             SpansContainer.get_span().update_event_response(
-                None, instance.status, instance.headers, partial_response
+                None, instance.status, dict(instance.headers.items()), partial_response
             )
         yield partial_response
 
@@ -281,6 +298,9 @@ def wrap_http_calls():
         with lumigo_safe_execute("wrap http calls"):
             get_logger().debug("wrapping the http request")
             wrap_function_wrapper("http.client", "HTTPConnection.send", _request_wrapper)
+            wrap_function_wrapper(
+                "http.client", "HTTPConnection.request", _headers_reminder_wrapper
+            )
             wrap_function_wrapper("botocore.awsrequest", "AWSRequest.__init__", _putheader_wrapper)
             wrap_function_wrapper("http.client", "HTTPConnection.getresponse", _response_wrapper)
             wrap_function_wrapper("http.client", "HTTPResponse.read", _read_wrapper)

--- a/src/lumigo_tracer/sync_http/sync_hook.py
+++ b/src/lumigo_tracer/sync_http/sync_hook.py
@@ -17,6 +17,7 @@ from lumigo_tracer.utils import (
     get_logger,
     lumigo_safe_execute,
     is_aws_environment,
+    ensure_str,
 )
 from lumigo_tracer.spans_container import SpansContainer, TimeoutMechanism
 from lumigo_tracer.parsers.http_data_classes import HttpRequest
@@ -55,7 +56,7 @@ def _request_wrapper(func, instance, args, kwargs):
             hooked_headers = getattr(instance, LUMIGO_HEADERS_HOOK_KEY, None)
             if hooked_headers:
                 # we will get here only if _headers_reminder_wrapper ran first. remove its traces.
-                headers = dict(hooked_headers.items())
+                headers = {ensure_str(k): ensure_str(v) for k, v in hooked_headers.items()}
                 setattr(instance, LUMIGO_HEADERS_HOOK_KEY, None)
             elif _FLAGS_HEADER_SPLITTER in headers:
                 request_info, headers = headers.split(_FLAGS_HEADER_SPLITTER, 1)

--- a/src/lumigo_tracer/utils.py
+++ b/src/lumigo_tracer/utils.py
@@ -237,7 +237,7 @@ def is_aws_environment():
     return bool(os.environ.get("LAMBDA_RUNTIME_DIR"))
 
 
-def ensure_str(s: Union[str, bytes]):
+def ensure_str(s: Union[str, bytes]) -> str:
     return s if isinstance(s, str) else s.decode()
 
 

--- a/src/lumigo_tracer/utils.py
+++ b/src/lumigo_tracer/utils.py
@@ -237,6 +237,10 @@ def is_aws_environment():
     return bool(os.environ.get("LAMBDA_RUNTIME_DIR"))
 
 
+def ensure_str(s: Union[str, bytes]):
+    return s if isinstance(s, str) else s.decode()
+
+
 def format_frames(frames_infos: List[inspect.FrameInfo]) -> List[dict]:
     free_space = MAX_VARS_SIZE
     frames: List[dict] = []

--- a/src/lumigo_tracer/utils.py
+++ b/src/lumigo_tracer/utils.py
@@ -23,7 +23,7 @@ TOO_BIG_SPANS_THRESHOLD = 5
 MAX_SIZE_FOR_REQUEST: int = int(os.environ.get("LUMIGO_MAX_SIZE_FOR_REQUEST", 900_000))
 MAX_VARS_SIZE = 100_000
 MAX_VAR_LEN = 200
-MAX_ENTRY_SIZE = 1024
+MAX_ENTRY_SIZE = 2048
 FrameVariables = Dict[str, str]
 OMITTING_KEYS_REGEXES = [
     ".*pass.*",
@@ -45,7 +45,6 @@ SKIP_SCRUBBING_KEYS = [EXECUTION_TAGS_KEY]
 LUMIGO_SECRET_MASKING_REGEX_BACKWARD_COMP = "LUMIGO_BLACKLIST_REGEX"
 LUMIGO_SECRET_MASKING_REGEX = "LUMIGO_SECRET_MASKING_REGEX"
 WARN_CLIENT_PREFIX = "Lumigo Warning"
-TIMEOUT_TIMER_BUFFER = 0.7
 NUMBER_OF_SPANS_IN_REPORT_OPTIMIZATION = 200
 
 _logger: Union[logging.Logger, None] = None
@@ -59,7 +58,7 @@ class Configuration:
     enhanced_print: bool = False
     is_step_function: bool = False
     timeout_timer: bool = True
-    timeout_timer_buffer: float = TIMEOUT_TIMER_BUFFER
+    timeout_timer_buffer: Optional[float] = None
     send_only_if_error: bool = False
     domains_scrubber: Optional[List] = None
 
@@ -72,7 +71,7 @@ def config(
     enhance_print: bool = False,
     step_function: bool = False,
     timeout_timer: bool = True,
-    timeout_timer_buffer: float = None,
+    timeout_timer_buffer: Optional[float] = None,
     domains_scrubber: Optional[List[str]] = None,
 ) -> None:
     """
@@ -85,7 +84,8 @@ def config(
     :param enhance_print: Should we add prefix to the print (so the logs will be in the platform).
     :param step_function: Is this function is a part of a step function?
     :param timeout_timer: Should we start a timer to send the traced data before timeout acceded.
-    :param timeout_timer_buffer: The buffer that we take before reaching timeout to send the traces to lumigo (seconds).
+    :param timeout_timer_buffer: The buffer (seconds) that we take before reaching timeout to send the traces to lumigo.
+        The default is 10% of the duration of the lambda (with upper and lower bounds of 0.5 and 3 seconds).
     :param domains_scrubber: List of regexes. We will not collect data of requests with hosts that match it.
     """
     if should_report is not None:
@@ -103,12 +103,13 @@ def config(
     )
     Configuration.timeout_timer = timeout_timer
     try:
-        Configuration.timeout_timer_buffer = float(  # type: ignore
-            timeout_timer_buffer or os.environ.get("LUMIGO_TIMEOUT_BUFFER", TIMEOUT_TIMER_BUFFER)
-        )
+        if "LUMIGO_TIMEOUT_BUFFER" in os.environ:
+            Configuration.timeout_timer_buffer = float(os.environ["LUMIGO_TIMEOUT_BUFFER"])
+        else:
+            Configuration.timeout_timer_buffer = timeout_timer_buffer
     except Exception:
         warn_client("Could not configure LUMIGO_TIMEOUT_BUFFER. Using default value.")
-        Configuration.timeout_timer_buffer = TIMEOUT_TIMER_BUFFER
+        Configuration.timeout_timer_buffer = None
     Configuration.send_only_if_error = os.environ.get("SEND_ONLY_IF_ERROR", "").lower() == "true"
     if domains_scrubber:
         domains_scrubber_regex = domains_scrubber
@@ -375,3 +376,10 @@ def is_api_gw_event(event: dict) -> bool:
         and event.get("requestContext", {}).get("domainName")  # noqa
         and event.get("requestContext", {}).get("requestId")  # noqa
     )
+
+
+def get_timeout_buffer(remaining_time: float):
+    buffer = Configuration.timeout_timer_buffer
+    if not buffer:
+        buffer = max(0.5, min(0.1 * remaining_time, 3))
+    return buffer

--- a/src/test/conftest.py
+++ b/src/test/conftest.py
@@ -71,4 +71,4 @@ def capture_all_logs(caplog):
 
 @pytest.fixture
 def context():
-    return mock.Mock(get_remaining_time_in_millis=lambda: utils.TIMEOUT_TIMER_BUFFER * 1000 * 2)
+    return mock.Mock(get_remaining_time_in_millis=lambda: 1000 * 2)

--- a/src/test/unit/parsers/test_parser.py
+++ b/src/test/unit/parsers/test_parser.py
@@ -1,11 +1,9 @@
 from lumigo_tracer.parsers.parser import ServerlessAWSParser, Parser, get_parser, ApiGatewayV2Parser
-import http.client
 
 
 def test_serverless_aws_parser_fallback_doesnt_change():
     url = "https://kvpuorrsqb.execute-api.us-west-2.amazonaws.com"
-    headers = http.client.HTTPMessage()
-    headers.add_header("nothing", "relevant")
+    headers = {"nothing": "relevant"}
     serverless_parser = ServerlessAWSParser().parse_response(url, 200, headers=headers, body=b"")
     root_parser = Parser().parse_response(url, 200, headers=headers, body=b"")
     serverless_parser.pop("ended")
@@ -15,21 +13,18 @@ def test_serverless_aws_parser_fallback_doesnt_change():
 
 def test_get_parser_check_headers():
     url = "api.rti.dev.toyota.com"
-    headers = http.client.HTTPMessage()
-    headers.add_header("x-amzn-requestid", "1234")
+    headers = {"x-amzn-requestid": "1234"}
     assert get_parser(url, headers) == ServerlessAWSParser
 
 
 def test_get_parser_apigw():
     url = "https://ne3kjv28fh.execute-api.us-west-2.amazonaws.com/doriaviram"
-    headers = http.client.HTTPMessage()
-    assert get_parser(url, headers) == ApiGatewayV2Parser
+    assert get_parser(url, {}) == ApiGatewayV2Parser
 
 
 def test_apigw_parse_response():
     parser = ApiGatewayV2Parser()
-    headers = http.client.HTTPMessage()
-    headers.add_header("Apigw-Requestid", "LY_66j0dPHcESCg=")
+    headers = {"apigw-requestid": "LY_66j0dPHcESCg="}
 
     result = parser.parse_response("dummy", 200, headers, body=b"")
 
@@ -38,7 +33,7 @@ def test_apigw_parse_response():
         "httpInfo": {
             "host": "dummy",
             "response": {
-                "headers": '{"Apigw-Requestid": "LY_66j0dPHcESCg="}',
+                "headers": '{"apigw-requestid": "LY_66j0dPHcESCg="}',
                 "body": "",
                 "statusCode": 200,
             },
@@ -48,18 +43,19 @@ def test_apigw_parse_response():
 
 def test_apigw_parse_response_with_aws_request_id():
     parser = ApiGatewayV2Parser()
-    headers = http.client.HTTPMessage()
-    headers.add_header("Apigw-Requestid", "LY_66j0dPHcESCg=")
-    headers.add_header("x-amzn-RequestId", "x-amzn-RequestId_LY_66j0dPHcESCg=")
+    headers = {
+        "apigw-requestid": "LY_66j0dPHcESCg=",
+        "x-amzn-requestid": "x-amzn-requestid_LY_66j0dPHcESCg=",
+    }
 
     result = parser.parse_response("dummy", 200, headers, body=b"")
 
     assert result["info"] == {
-        "messageId": "x-amzn-RequestId_LY_66j0dPHcESCg=",
+        "messageId": "x-amzn-requestid_LY_66j0dPHcESCg=",
         "httpInfo": {
             "host": "dummy",
             "response": {
-                "headers": '{"Apigw-Requestid": "LY_66j0dPHcESCg=", "x-amzn-RequestId": "x-amzn-RequestId_LY_66j0dPHcESCg="}',
+                "headers": '{"apigw-requestid": "LY_66j0dPHcESCg=", "x-amzn-requestid": "x-amzn-requestid_LY_66j0dPHcESCg="}',
                 "body": "",
                 "statusCode": 200,
             },

--- a/src/test/unit/parsers/test_utils.py
+++ b/src/test/unit/parsers/test_utils.py
@@ -332,7 +332,7 @@ def test_safe_get(d, keys, result_value, default):
     [(["secret.*"], "lumigo.io", False), (["not-relevant", "secret.*"], "secret.aws.com", True)],
 )
 def test_should_scrub_domain(regexes, url, expected):
-    Configuration.domains_scrubber = regexes
+    config(domains_scrubber=regexes)
     assert should_scrub_domain(url) == expected
 
 

--- a/src/test/unit/sync_http/test_sync_hook.py
+++ b/src/test/unit/sync_http/test_sync_hook.py
@@ -553,7 +553,7 @@ def test_correct_headers_of_send_after_request():
     def lambda_test_function(event, context):
         d = {"a": "b", "myPassword": "123"}
         conn = http.client.HTTPConnection("www.google.com")
-        conn.request("POST", "/", json.dumps(d), headers={"a": "b"})
+        conn.request("POST", "/", json.dumps(d), headers={"a": b"b"})
         conn.send(b"GET\r\nc: d\r\n\r\nbody")
         return {"lumigo": "rulz"}
 

--- a/src/test/unit/test_main_utils.py
+++ b/src/test/unit/test_main_utils.py
@@ -22,7 +22,7 @@ from lumigo_tracer.utils import (
     warn_client,
     WARN_CLIENT_PREFIX,
     SKIP_SCRUBBING_KEYS,
-    TIMEOUT_TIMER_BUFFER,
+    get_timeout_buffer,
 )
 import json
 
@@ -319,7 +319,7 @@ def test_config_enhanced_printstep_function_without_envs(monkeypatch, configurat
 def test_config_timeout_timer_buffer_with_exception(monkeypatch):
     monkeypatch.setenv("LUMIGO_TIMEOUT_BUFFER", "not float")
     config()
-    assert Configuration.timeout_timer_buffer == TIMEOUT_TIMER_BUFFER
+    assert Configuration.timeout_timer_buffer is None
 
 
 def test_warn_client_print(capsys):
@@ -331,3 +331,12 @@ def test_warn_client_dont_print(capsys, monkeypatch):
     monkeypatch.setenv("LUMIGO_WARNINGS", "off")
     warn_client("message")
     assert capsys.readouterr().out == ""
+
+
+@pytest.mark.parametrize(
+    "remaining_time, conf, expected",
+    ((3, 1, 1), (3, None, 0.5), (10, None, 1), (20, None, 2), (900, None, 3)),
+)
+def test_get_timeout_buffer(remaining_time, conf, expected):
+    Configuration.timeout_timer_buffer = conf
+    assert get_timeout_buffer(remaining_time) == expected

--- a/src/test/unit/test_spans_container.py
+++ b/src/test/unit/test_spans_container.py
@@ -93,9 +93,7 @@ def test_timeout_mechanism_disabled_by_configuration(monkeypatch, context):
 
 def test_timeout_mechanism_too_short_time(monkeypatch, context):
     monkeypatch.setattr(Configuration, "timeout_timer", True)
-    monkeypatch.setattr(
-        context, "get_remaining_time_in_millis", lambda: utils.TIMEOUT_TIMER_BUFFER / 2
-    )
+    monkeypatch.setattr(context, "get_remaining_time_in_millis", lambda: 1000)
     SpansContainer.create_span()
     SpansContainer.get_span().start(context=context)
 


### PR DESCRIPTION
banchmark: lambda with 256MB memory, doing 10,000 ddb get_item requests, with xray that close a segment every 1000 requests.
Without lumigo: 241s
With old lumigo: 320s
with new lumigo: 292s
I.e. total of 35.5% less overhead