### PR TITLE
Double envs and event size limit on error

### DIFF
--- a/src/lumigo_tracer/lumigo_utils.py
+++ b/src/lumigo_tracer/lumigo_utils.py
@@ -55,6 +55,7 @@ NUMBER_OF_SPANS_IN_REPORT_OPTIMIZATION = 200
 DEFAULT_KEY_DEPTH = 4
 LUMIGO_TOKEN_KEY = "LUMIGO_TRACER_TOKEN"
 KILL_SWITCH = "LUMIGO_SWITCH_OFF"
+ERROR_SIZE_LIMIT_MULTIPLIER = 2
 
 _logger: Dict[str, logging.Logger] = {}
 
@@ -87,7 +88,7 @@ class Configuration:
     @staticmethod
     def get_max_entry_size(has_error: bool = False) -> int:
         if has_error:
-            return Configuration.max_entry_size * 2
+            return Configuration.max_entry_size * ERROR_SIZE_LIMIT_MULTIPLIER
         return Configuration.max_entry_size
 
 

--- a/src/lumigo_tracer/lumigo_utils.py
+++ b/src/lumigo_tracer/lumigo_utils.py
@@ -84,6 +84,12 @@ class Configuration:
     max_entry_size: int = DEFAULT_MAX_ENTRY_SIZE
     get_key_depth: int = DEFAULT_KEY_DEPTH
 
+    @staticmethod
+    def get_max_entry_size(has_error: bool = False) -> int:
+        if has_error:
+            return Configuration.max_entry_size * 2
+        return Configuration.max_entry_size
+
 
 def config(
     edge_host: str = "",

--- a/src/lumigo_tracer/tracer.py
+++ b/src/lumigo_tracer/tracer.py
@@ -66,7 +66,8 @@ def _lumigo_tracer(func):
                     SpansContainer.get_span().add_exception_event(e, inspect.trace())
                 raise
             finally:
-                SpansContainer.get_span().end(ret_val)
+                event = args[0] if len(args) > 0 else None
+                SpansContainer.get_span().end(event, ret_val)
                 if Configuration.enhanced_print:
                     builtins.print = local_print
                     logging.Formatter.format = local_logging_format

--- a/src/lumigo_tracer/tracer.py
+++ b/src/lumigo_tracer/tracer.py
@@ -66,8 +66,7 @@ def _lumigo_tracer(func):
                     SpansContainer.get_span().add_exception_event(e, inspect.trace())
                 raise
             finally:
-                event = args[0] if len(args) > 0 else None
-                SpansContainer.get_span().end(event, ret_val)
+                SpansContainer.get_span().end(ret_val, *args)
                 if Configuration.enhanced_print:
                     builtins.print = local_print
                     logging.Formatter.format = local_logging_format

--- a/src/test/unit/event/test_event_dumper.py
+++ b/src/test/unit/event/test_event_dumper.py
@@ -1,3 +1,4 @@
+import json
 from collections import OrderedDict
 import pytest
 
@@ -480,10 +481,12 @@ def test_parse_cloudfront_event(cloudfront_event):
 
 
 def test_dump_event_has_error_should_double_limit_size():
-    event = {"k": "v" * Configuration.get_max_entry_size() * 3}
+    long_string = "v" * int(Configuration.get_max_entry_size() * 1.5)
+    event = {"k": long_string}
     result_no_error = EventDumper.dump_event(event)
     result_has_error = EventDumper.dump_event(event, has_error=True)
-    assert len(result_has_error) > len(result_no_error) * 1.8 + 1
+    assert len(result_has_error) > len(result_no_error)
+    assert result_has_error == json.dumps(event)
 
 
 @pytest.fixture

--- a/src/test/unit/event/test_event_dumper.py
+++ b/src/test/unit/event/test_event_dumper.py
@@ -7,7 +7,7 @@ from lumigo_tracer.event.event_dumper import (
     CloudfrontHandler,
     S3Handler,
 )
-from lumigo_tracer.lumigo_utils import lumigo_dumps
+from lumigo_tracer.lumigo_utils import lumigo_dumps, Configuration
 
 
 class ExceptionHandler(EventParseHandler):
@@ -477,6 +477,13 @@ def test_parse_cloudfront_event(cloudfront_event):
             }
         )
     )
+
+
+def test_dump_event_has_error_should_double_limit_size():
+    event = {"k": "v" * Configuration.get_max_entry_size() * 3}
+    result_no_error = EventDumper.dump_event(event)
+    result_has_error = EventDumper.dump_event(event, has_error=True)
+    assert len(result_has_error) > len(result_no_error) * 1.8 + 1
 
 
 @pytest.fixture

--- a/src/test/unit/test_lumigo_utils.py
+++ b/src/test/unit/test_lumigo_utils.py
@@ -388,3 +388,11 @@ def test_report_json_retry(monkeypatch, reporter_mock, caplog, errors, final_log
 def test_is_kill_switch_on(monkeypatch, env, expected):
     monkeypatch.setenv(KILL_SWITCH, env)
     assert is_kill_switch_on() == expected
+
+
+def test_get_max_entry_size_default(monkeypatch):
+    assert Configuration.get_max_entry_size() == 2048
+
+
+def test_get_max_entry_size_has_error():
+    assert Configuration.get_max_entry_size(has_error=True) == 4096

--- a/src/test/unit/test_spans_container.py
+++ b/src/test/unit/test_spans_container.py
@@ -1,5 +1,6 @@
 import copy
 import inspect
+import json
 
 import pytest
 
@@ -84,7 +85,7 @@ def test_spans_container_end_function_send_only_on_errors_mode_false_not_effecti
 
 
 def test_spans_container_end_function_with_error_double_size_limit(monkeypatch, dummy_span):
-    long_string = "v" * Configuration.get_max_entry_size() * 3
+    long_string = "v" * int(Configuration.get_max_entry_size() * 1.5)
     monkeypatch.setenv("LONG_STRING", long_string)
     event = {"k": long_string}
     SpansContainer.create_span(event)
@@ -92,11 +93,11 @@ def test_spans_container_end_function_with_error_double_size_limit(monkeypatch, 
     start_span = copy.deepcopy(SpansContainer.get_span().function_span)
     SpansContainer.get_span().add_exception_event(Exception("Some Error"), inspect.trace())
 
-    SpansContainer.get_span().end(event)
+    SpansContainer.get_span().end(event=event)
 
     end_span = SpansContainer.get_span().function_span
-    assert len(end_span["event"]) > len(start_span["event"]) * 1.8 + 1
-    assert len(end_span["envs"]) > len(start_span["envs"]) * 1.8 + 1
+    assert len(end_span["event"]) > len(start_span["event"])
+    assert end_span["event"] == json.dumps(event)
 
 
 def test_spans_container_timeout_mechanism_send_only_on_errors_mode(


### PR DESCRIPTION
Example:
The event is longer than 3000 chars
On lambda success:
![image](https://user-images.githubusercontent.com/49228804/96086011-4ba1a700-0eca-11eb-9d66-768fb21869da.png)
On lambda exception:
![image](https://user-images.githubusercontent.com/49228804/96086083-62e09480-0eca-11eb-92f4-2d41fe327b6c.png)
