### PR TITLE
RD-4424 - cold start indication in pre-invocation calls

### DIFF
--- a/src/lumigo_tracer/tracer.py
+++ b/src/lumigo_tracer/tracer.py
@@ -54,7 +54,7 @@ def _lumigo_tracer(func):
         try:
             if Configuration.enhanced_print:
                 _enhance_output(args, local_print, local_logging_format)
-            SpansContainer.create_span(*args, force=True)
+            SpansContainer.create_span(*args, is_new_invocation=True)
             with lumigo_safe_execute("auto tag"):
                 AutoTagEvent.auto_tag_event(args[0])
             SpansContainer.get_span().start(*args)

--- a/src/test/unit/test_tracer.py
+++ b/src/test/unit/test_tracer.py
@@ -465,13 +465,16 @@ def test_lumigo_tracer_doesnt_change_exception(context):
     assert from_lumigo == original
 
 
-def test_cold_indicator_with_request_in_cold_phase():
+def test_cold_indicator_with_request_in_cold_phase(context):
     SpansContainer.is_cold = True
     #  Create a request the might invert the `is_cold` field
     http.client.HTTPConnection("www.google.com").request("POST", "/")
+    assert SpansContainer.is_cold is True
 
     @lumigo_tracer(step_function=True)
     def lambda_test_function(event, context):
         http.client.HTTPConnection("www.google.com").request("POST", "/")
 
+    lambda_test_function({}, context)
     assert SpansContainer.get_span().function_span["readiness"] == "cold"
+    assert SpansContainer.is_cold is False


### PR DESCRIPTION
If someone initializes an AWS connection during the cold start phase, then we will create a spans_container, thus marking this container as “hot”.
I changed the behavior to mark it as “hot” only when creating a span_container due to *invocation start*.