### PR TITLE
Rd 6294 python tracer extension with timeout flow is flaky

### DIFF
--- a/src/lumigo_tracer/lumigo_utils.py
+++ b/src/lumigo_tracer/lumigo_utils.py
@@ -94,7 +94,7 @@ def should_use_tracer_extension() -> bool:
 
 
 def get_extension_dir() -> str:
-    return (os.environ.get(LUMIGO_SPANS_DIR) or LUMIGO_SPANS_DIR).lower()
+    return (os.environ.get("LUMIGO_SPANS_DIR_KEY") or LUMIGO_SPANS_DIR).lower()
 
 
 def get_region() -> str:
@@ -396,7 +396,7 @@ def write_spans_to_files(
     spans: List[Dict], max_spans=MAX_NUMBER_OF_SPANS, is_start_span=True
 ) -> None:
     to_send = spans[:max_spans]
-    Path(LUMIGO_SPANS_DIR).mkdir(parents=True, exist_ok=True)
+    Path(get_extension_dir()).mkdir(parents=True, exist_ok=True)
     if is_start_span:
         get_logger().info("Creating start span file")
         write_extension_file(to_send, "span")

--- a/src/lumigo_tracer/lumigo_utils.py
+++ b/src/lumigo_tracer/lumigo_utils.py
@@ -94,7 +94,7 @@ def should_use_tracer_extension() -> bool:
 
 
 def get_extension_dir() -> str:
-    return (os.environ.get("LUMIGO_SPANS_DIR_KEY") or LUMIGO_SPANS_DIR).lower()
+    return (os.environ.get("LUMIGO_EXTENSION_SPANS_DIR_KEY") or LUMIGO_SPANS_DIR).lower()
 
 
 def get_region() -> str:

--- a/src/lumigo_tracer/lumigo_utils.py
+++ b/src/lumigo_tracer/lumigo_utils.py
@@ -75,7 +75,7 @@ NUMBER_OF_SPANS_IN_REPORT_OPTIMIZATION = 200
 DEFAULT_KEY_DEPTH = 4
 LUMIGO_TOKEN_KEY = "LUMIGO_TRACER_TOKEN"
 LUMIGO_USE_TRACER_EXTENSION = "LUMIGO_USE_TRACER_EXTENSION"
-EXTENSION_DIR = "/tmp/lumigo-spans"
+LUMIGO_SPANS_DIR = "/tmp/lumigo-spans"
 KILL_SWITCH = "LUMIGO_SWITCH_OFF"
 ERROR_SIZE_LIMIT_MULTIPLIER = 2
 CHINA_REGION = "cn-northwest-1"
@@ -92,6 +92,9 @@ edge_connection = None
 def should_use_tracer_extension() -> bool:
     return (os.environ.get(LUMIGO_USE_TRACER_EXTENSION) or "false").lower() == "true"
 
+
+def get_extension_dir() -> str:
+    return (os.environ.get(LUMIGO_SPANS_DIR) or LUMIGO_SPANS_DIR).lower()
 
 def get_region() -> str:
     return os.environ.get("AWS_REGION") or "UNKNOWN"
@@ -378,7 +381,7 @@ def report_json(
 def write_extension_file(data: List[Dict], span_type: str):
     to_send = aws_dump(data).encode()
     file_name = f"{hashlib.md5(to_send).hexdigest()}_{span_type}"
-    file_path = os.path.join(EXTENSION_DIR, file_name)
+    file_path = os.path.join(LUMIGO_SPANS_DIR, file_name)
     with open(file_path, "wb") as span_file:
         span_file.write(to_send)
         get_logger().info(f"Wrote span to file to [{file_path}]")
@@ -388,7 +391,7 @@ def write_spans_to_files(
     spans: List[Dict], max_spans=MAX_NUMBER_OF_SPANS, is_start_span=True
 ) -> None:
     to_send = spans[:max_spans]
-    Path(EXTENSION_DIR).mkdir(parents=True, exist_ok=True)
+    Path(LUMIGO_SPANS_DIR).mkdir(parents=True, exist_ok=True)
     if is_start_span:
         get_logger().info("Creating start span file")
         write_extension_file(to_send, "span")

--- a/src/lumigo_tracer/lumigo_utils.py
+++ b/src/lumigo_tracer/lumigo_utils.py
@@ -383,11 +383,11 @@ def write_extension_file(data: dict, span_type: str):
     file_path = os.path.join(EXTENSION_DIR, file_name)
     with open(file_path, "wb") as span_file:
         span_file.write(to_send)
+        get_logger().info(f"wrote span to file to [{file_path}]")
 
 
 def write_spans_to_files(spans: List[Dict], max_spans=MAX_NUMBER_OF_SPANS, with_done=True) -> None:
     to_send = spans[:max_spans]
-    get_logger().info(f"writing [{len(to_send)}] spans to files to [{EXTENSION_DIR}]")
     Path(EXTENSION_DIR).mkdir(parents=True, exist_ok=True)
     for span in to_send:
         write_extension_file(span, "span")

--- a/src/lumigo_tracer/lumigo_utils.py
+++ b/src/lumigo_tracer/lumigo_utils.py
@@ -383,7 +383,7 @@ def write_extension_file(data: dict, span_type: str):
     file_path = os.path.join(EXTENSION_DIR, file_name)
     with open(file_path, "wb") as span_file:
         span_file.write(to_send)
-        get_logger().info(f"wrote span to file to [{file_path}]")
+        get_logger().info(f"Wrote span to file to [{file_path}]")
 
 
 def write_spans_to_files(spans: List[Dict], max_spans=MAX_NUMBER_OF_SPANS, with_done=True) -> None:

--- a/src/lumigo_tracer/lumigo_utils.py
+++ b/src/lumigo_tracer/lumigo_utils.py
@@ -96,6 +96,7 @@ def should_use_tracer_extension() -> bool:
 def get_extension_dir() -> str:
     return (os.environ.get(LUMIGO_SPANS_DIR) or LUMIGO_SPANS_DIR).lower()
 
+
 def get_region() -> str:
     return os.environ.get("AWS_REGION") or "UNKNOWN"
 

--- a/src/lumigo_tracer/lumigo_utils.py
+++ b/src/lumigo_tracer/lumigo_utils.py
@@ -46,7 +46,6 @@ MAX_NUMBER_OF_SPANS: int = int(os.environ.get("LUMIGO_MAX_NUMBER_OF_SPANS", 2000
 EDGE_TIMEOUT = float(os.environ.get("LUMIGO_EDGE_TIMEOUT", SECONDS_TO_TIMEOUT))
 MAX_VARS_SIZE = 100_000
 MAX_VAR_LEN = 1024
-EXTENSION_FILE_SUFFIX = "#DONE#"
 DEFAULT_MAX_ENTRY_SIZE = 2048
 FrameVariables = Dict[str, str]
 OMITTING_KEYS_REGEXES = [
@@ -338,8 +337,7 @@ def report_json(
         return 0
     if should_use_tracer_extension():
         with lumigo_safe_execute("report json file: writing spans to file"):
-            with_done = not is_start_span
-            write_spans_to_files(spans=msgs, with_done=with_done)
+            write_spans_to_files(spans=msgs, is_start_span=is_start_span)
         return 0
     if region == CHINA_REGION:
         return _publish_spans_to_kinesis(to_send, CHINA_REGION)
@@ -377,8 +375,8 @@ def report_json(
     return duration
 
 
-def write_extension_file(data: dict, span_type: str):
-    to_send = aws_dump(data).encode() + EXTENSION_FILE_SUFFIX.encode()
+def write_extension_file(data: List[Dict], span_type: str):
+    to_send = aws_dump(data).encode()
     file_name = f"{hashlib.md5(to_send).hexdigest()}_{span_type}"
     file_path = os.path.join(EXTENSION_DIR, file_name)
     with open(file_path, "wb") as span_file:
@@ -386,18 +384,17 @@ def write_extension_file(data: dict, span_type: str):
         get_logger().info(f"Wrote span to file to [{file_path}]")
 
 
-def write_spans_to_files(spans: List[Dict], max_spans=MAX_NUMBER_OF_SPANS, with_done=True) -> None:
+def write_spans_to_files(
+    spans: List[Dict], max_spans=MAX_NUMBER_OF_SPANS, is_start_span=True
+) -> None:
     to_send = spans[:max_spans]
     Path(EXTENSION_DIR).mkdir(parents=True, exist_ok=True)
-    for span in to_send:
-        write_extension_file(span, "span")
-    if with_done:
-        done_object = {
-            "random": os.urandom(12).hex(),
-            "spansCount": len(to_send) + int(not Configuration.send_only_if_error),
-        }  # plus the start span
-        get_logger().info(f"Created done - {done_object}")
-        write_extension_file(done_object, "done")
+    if is_start_span:
+        get_logger().info("Creating start span file")
+        write_extension_file(to_send, "span")
+    else:
+        get_logger().info("Creating end span file")
+        write_extension_file(to_send, "end")
 
 
 def _publish_spans_to_kinesis(to_send: bytes, region: str) -> int:

--- a/src/lumigo_tracer/lumigo_utils.py
+++ b/src/lumigo_tracer/lumigo_utils.py
@@ -378,10 +378,14 @@ def report_json(
     return duration
 
 
+def get_span_file_name(span_type: str):
+    unique_name = str(uuid.uuid4())
+    return os.path.join(get_extension_dir(), f"{unique_name}_{span_type}")
+
+
 def write_extension_file(data: List[Dict], span_type: str):
     to_send = aws_dump(data).encode()
-    file_name = f"{hashlib.md5(to_send).hexdigest()}_{span_type}"
-    file_path = os.path.join(LUMIGO_SPANS_DIR, file_name)
+    file_path = get_span_file_name(span_type)
     with open(file_path, "wb") as span_file:
         span_file.write(to_send)
         get_logger().info(f"Wrote span to file to [{file_path}]")

--- a/src/lumigo_tracer/lumigo_utils.py
+++ b/src/lumigo_tracer/lumigo_utils.py
@@ -393,7 +393,8 @@ def write_spans_to_files(spans: List[Dict], max_spans=MAX_NUMBER_OF_SPANS, with_
         write_extension_file(span, "span")
     if with_done:
         done_object = {
-            "spansCount": len(to_send) + int(not Configuration.send_only_if_error)
+            "random": os.urandom(12).hex(),
+            "spansCount": len(to_send) + int(not Configuration.send_only_if_error),
         }  # plus the start span
         get_logger().info(f"Created done - {done_object}")
         write_extension_file(done_object, "done")

--- a/src/test/unit/test_lumigo_utils.py
+++ b/src/test/unit/test_lumigo_utils.py
@@ -468,7 +468,7 @@ def test_report_json_extension_spans_mode(monkeypatch, reporter_mock, tmpdir):
     report_json(region=None, msgs=start_span, is_start_span=True)
 
     spans = []
-    size_factor = 1
+    size_factor = 100
     for i in range(size_factor):
         spans.append(
             {

--- a/src/test/unit/test_lumigo_utils.py
+++ b/src/test/unit/test_lumigo_utils.py
@@ -1,6 +1,5 @@
 import importlib.util
 import inspect
-import hashlib
 import logging
 import os
 import uuid
@@ -12,7 +11,7 @@ import socket
 from unittest.mock import Mock
 
 import boto3
-from mock import Mock, MagicMock
+from mock import MagicMock
 
 import pytest
 from lumigo_tracer import lumigo_utils
@@ -48,7 +47,6 @@ from lumigo_tracer.lumigo_utils import (
     internal_analytics_message,
     INTERNAL_ANALYTICS_PREFIX,
     InternalState,
-    aws_dump,
     concat_old_body_to_new,
     TRUNCATE_SUFFIX,
 )
@@ -482,7 +480,6 @@ def test_report_json_extension_spans_mode(monkeypatch, reporter_mock, tmpdir):
     end_file_content = json.loads(open(end_path_path, "r").read())
     assert start_span == start_file_content
     assert json.dumps(end_file_content) == json.dumps(spans)
-
 
 
 @pytest.mark.parametrize(

--- a/src/test/unit/test_lumigo_utils.py
+++ b/src/test/unit/test_lumigo_utils.py
@@ -464,7 +464,7 @@ def test_report_json_extension_spans_mode(monkeypatch, reporter_mock):
     report_json(region=None, msgs=start_span, is_start_span=True)
 
     spans = []
-    size_factor = 2
+    size_factor = 100
     for i in range(size_factor):
         spans.append(
             {

--- a/src/test/unit/test_lumigo_utils.py
+++ b/src/test/unit/test_lumigo_utils.py
@@ -455,10 +455,10 @@ def test_get_edge_host(arg, host, monkeypatch):
 
 def test_report_json_extension_spans_mode(monkeypatch, reporter_mock, tmpdir):
     extension_dir = tmpdir.mkdir("tmp")
-    monkeypatch.setattr(lumigo_utils, "get_extension_dir", lambda *args, **kwargs: extension_dir)
     monkeypatch.setattr(uuid, "uuid4", lambda *args, **kwargs: "span_name")
     monkeypatch.setattr(Configuration, "should_report", True)
     monkeypatch.setenv("LUMIGO_USE_TRACER_EXTENSION", "TRUE")
+    monkeypatch.setenv("LUMIGO_EXTENSION_SPANS_DIR_KEY", extension_dir)
     mocked_urandom = MagicMock(hex=MagicMock(return_value="my_mocked_data"))
     monkeypatch.setattr(os, "urandom", lambda *args, **kwargs: mocked_urandom)
 

--- a/src/test/unit/test_lumigo_utils.py
+++ b/src/test/unit/test_lumigo_utils.py
@@ -2,6 +2,7 @@ import importlib.util
 import inspect
 import hashlib
 import logging
+import os
 from collections import OrderedDict
 from decimal import Decimal
 import datetime
@@ -457,6 +458,10 @@ def test_get_edge_host(arg, host, monkeypatch):
 def test_report_json_extension_spans_mode(monkeypatch, reporter_mock):
     monkeypatch.setattr(Configuration, "should_report", True)
     monkeypatch.setenv("LUMIGO_USE_TRACER_EXTENSION", "TRUE")
+    mocked_urandom = MagicMock()
+    mocked_urandom.hex = MagicMock(return_value="my_mocked_data")
+    monkeypatch.setattr(os, "urandom", lambda *args, **kwargs: mocked_urandom)
+    assert os.urandom(12).hex() == "my_mocked_data"
     spans = []
     size_factor = 100
     for i in range(size_factor):
@@ -470,7 +475,7 @@ def test_report_json_extension_spans_mode(monkeypatch, reporter_mock):
     files_paths = []
     for span in spans:
         files_paths.append(get_span_file_name(span, "span"))
-    done_object = {"spansCount": len(spans) + 1}
+    done_object = {"random": "my_mocked_data", "spansCount": len(spans) + 1}
     files_paths.append(get_span_file_name(done_object, "done"))
     files = glob.glob("/tmp/lumigo-spans/*")
     assert len(files) == size_factor + 1

--- a/src/test/unit/test_lumigo_utils.py
+++ b/src/test/unit/test_lumigo_utils.py
@@ -461,7 +461,6 @@ def test_report_json_extension_spans_mode(monkeypatch, reporter_mock):
     mocked_urandom = MagicMock()
     mocked_urandom.hex = MagicMock(return_value="my_mocked_data")
     monkeypatch.setattr(os, "urandom", lambda *args, **kwargs: mocked_urandom)
-    assert os.urandom(12).hex() == "my_mocked_data"
     spans = []
     size_factor = 100
     for i in range(size_factor):

--- a/src/test/unit/test_lumigo_utils.py
+++ b/src/test/unit/test_lumigo_utils.py
@@ -454,8 +454,8 @@ def test_get_edge_host(arg, host, monkeypatch):
 
 
 def test_report_json_extension_spans_mode(monkeypatch, reporter_mock, tmpdir):
-    extension_dor = tmpdir.mkdir("tmp")
-    monkeypatch.setattr(lumigo_utils, "get_extension_dir", lambda *args, **kwargs: extension_dor)
+    extension_dir = tmpdir.mkdir("tmp")
+    monkeypatch.setattr(lumigo_utils, "get_extension_dir", lambda *args, **kwargs: extension_dir)
     monkeypatch.setattr(uuid, "uuid4", lambda *args, **kwargs: "span_name")
     monkeypatch.setattr(Configuration, "should_report", True)
     monkeypatch.setenv("LUMIGO_USE_TRACER_EXTENSION", "TRUE")

--- a/src/test/unit/test_lumigo_utils.py
+++ b/src/test/unit/test_lumigo_utils.py
@@ -453,11 +453,11 @@ def test_get_edge_host(arg, host, monkeypatch):
     assert get_edge_host("region") == host
 
 
-def test_report_json_extension_spans_mode(monkeypatch, reporter_mock):
+def test_report_json_extension_spans_mode(monkeypatch, reporter_mock, tmpdir):
+    monkeypatch.setattr(lumigo_utils, "get_extension_dir", lambda *args, **kwargs: "tmp")
     monkeypatch.setattr(Configuration, "should_report", True)
     monkeypatch.setenv("LUMIGO_USE_TRACER_EXTENSION", "TRUE")
-    mocked_urandom = MagicMock()
-    mocked_urandom.hex = MagicMock(return_value="my_mocked_data")
+    mocked_urandom = MagicMock(hex=MagicMock(return_value="my_mocked_data"))
     monkeypatch.setattr(os, "urandom", lambda *args, **kwargs: mocked_urandom)
 
     start_span = [{"span": "true"}]

--- a/src/test/unit/test_spans_container.py
+++ b/src/test/unit/test_spans_container.py
@@ -48,7 +48,7 @@ def test_start(monkeypatch):
     monkeypatch.setattr(SpansContainer, "_generate_start_span", lambda *args, **kwargs: {"a": "a"})
     monkeypatch.setattr(Configuration, "should_report", True)
     SpansContainer().start()
-    lumigo_utils_mock.assert_called_once_with({"a": "a"}, "span")
+    lumigo_utils_mock.assert_called_once_with([{"a": "a"}], "span")
 
 
 def test_spans_container_end_function_got_none_return_value(monkeypatch):


### PR DESCRIPTION
The Extension now expects always two files:
XXX_span nd XXX_end
where XXX_span represents the start span as List[span] (length = 1) and  XXX_end that is List[span] (length = all the rest)
also, we removed the #DONE" from the suffix of files data since the extension validate the file stopped changing after T time