### PR TITLE
Allow this library to be used as a general parsing library

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -168,14 +168,14 @@
         "filename": "src/test/unit/event/test_event_trigger.py",
         "hashed_secret": "885bb9903f72e004ff2974807b70e7c970d3e6d5",
         "is_verified": false,
-        "line_number": 567
+        "line_number": 612
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/test/unit/event/test_event_trigger.py",
         "hashed_secret": "3fae06dc55a618caed1d794dcd512bfe7e76c9f1",
         "is_verified": false,
-        "line_number": 612
+        "line_number": 657
       }
     ],
     "src/test/unit/test_lumigo_utils.py": [
@@ -220,5 +220,5 @@
       }
     ]
   },
-  "generated_at": "2023-01-22T08:40:16Z"
+  "generated_at": "2023-01-22T10:15:06Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -115,14 +115,14 @@
         "filename": "src/lumigo_tracer/lumigo_utils.py",
         "hashed_secret": "116b0dcbb1dfb3f19c902ebfc29f35d908cec6a4",
         "is_verified": false,
-        "line_number": 69
+        "line_number": 48
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lumigo_tracer/lumigo_utils.py",
         "hashed_secret": "2a93870f6e6a2158cb9631b349e75d8f65fd81af",
         "is_verified": false,
-        "line_number": 70
+        "line_number": 49
       }
     ],
     "src/test/unit/event/test_event_dumper.py": [
@@ -184,7 +184,7 @@
         "filename": "src/test/unit/test_lumigo_utils.py",
         "hashed_secret": "f32b67c7e26342af42efabc674d441dca0a281c5",
         "is_verified": false,
-        "line_number": 263
+        "line_number": 199
       }
     ],
     "src/test/unit/test_tracer.py": [
@@ -220,5 +220,5 @@
       }
     ]
   },
-  "generated_at": "2022-11-08T16:26:37Z"
+  "generated_at": "2023-01-22T08:40:16Z"
 }

--- a/src/lumigo_tracer/__init__.py
+++ b/src/lumigo_tracer/__init__.py
@@ -1,4 +1,4 @@
-from .tracer import lumigo_tracer, LumigoChalice  # noqa
+from lumigo_tracer.lambda_tracer.tracer import lumigo_tracer, LumigoChalice  # noqa
 from .user_utils import (  # noqa
     report_error,
     add_execution_tag,
@@ -9,3 +9,6 @@ from .user_utils import (  # noqa
     error,
 )
 from .auto_instrument_handler import _handler  # noqa
+from .lambda_tracer.global_scope_exec import global_scope_exec
+
+global_scope_exec()

--- a/src/lumigo_tracer/auto_instrument_handler.py
+++ b/src/lumigo_tracer/auto_instrument_handler.py
@@ -1,5 +1,7 @@
 import os
 
+from lumigo_tracer.lumigo_utils import is_aws_environment
+
 try:
     # Try to import AWS's current _get_handler logic
     from bootstrap import _get_handler as aws_get_handler
@@ -27,8 +29,15 @@ def _handler(*args, **kwargs):  # type: ignore[no-untyped-def]
     return original_handler(*args, **kwargs)
 
 
-try:
-    # import handler during runtime initialization, as usual.
-    get_original_handler()
-except Exception:
-    pass
+def prefetch_handler_import() -> None:
+    """
+    This function imports the handler.
+    When we call it in the global scope, it will be executed during the lambda initialization,
+        thus will mimic the usual behavior.
+    """
+    if not is_aws_environment():
+        return
+    try:
+        get_original_handler()
+    except Exception:
+        pass

--- a/src/lumigo_tracer/event/event_trigger.py
+++ b/src/lumigo_tracer/event/event_trigger.py
@@ -6,8 +6,8 @@ from lumigo_tracer.event.trigger_parsing.event_trigger_base import TriggerType
 from lumigo_tracer.lumigo_utils import Configuration, get_logger
 
 
-def _recursive_parse_trigger_by(
-    message: Dict[Any, Any], parent_id: Optional[str], level: int
+def recursive_parse_trigger(
+    message: Dict[Any, Any], parent_id: Optional[str] = None, level: int = 0
 ) -> List[TriggerType]:
     triggers = []
     if level >= Configuration.chained_services_max_depth:
@@ -27,7 +27,7 @@ def _recursive_parse_trigger_by(
                 if INNER_MESSAGES_MAGIC_PATTERN.search(sub_message):
                     # We want to load only relevant messages, so first run a quick scan
                     triggers.extend(
-                        _recursive_parse_trigger_by(
+                        recursive_parse_trigger(
                             json.loads(sub_message), parent_id=current_trigger_id, level=level + 1
                         )
                     )
@@ -36,4 +36,4 @@ def _recursive_parse_trigger_by(
 
 
 def parse_triggers(event: Dict[Any, Any]) -> List[Dict[Any, Any]]:
-    return _recursive_parse_trigger_by(event, parent_id=None, level=0)
+    return recursive_parse_trigger(event, parent_id=None, level=0)

--- a/src/lumigo_tracer/event/trigger_parsing/sqs_parser.py
+++ b/src/lumigo_tracer/event/trigger_parsing/sqs_parser.py
@@ -10,32 +10,40 @@ from lumigo_tracer.event.trigger_parsing.event_trigger_base import (
 class SqsEventTriggerParser(EventTriggerParser):
     @staticmethod
     def _should_handle(event: Dict[Any, Any]) -> bool:
-        return bool(event.get("Records", [{}])[0].get("eventSource") == "aws:sqs")
+        return bool(event.get("Records", [{}])[0].get("eventSource") == "aws:sqs") or bool(
+            event.get("service_name") == "sqs" and event.get("operation_name") == "ReceiveMessage"
+        )
+
+    @staticmethod
+    def _get_messages(event: Dict[Any, Any]) -> List[Dict[Any, Any]]:
+        return event.get("Records", []) + event.get("Messages", [])  # type: ignore
 
     @staticmethod
     def handle(event: Dict[Any, Any], target_id: Optional[str]) -> TriggerType:
+        messages = SqsEventTriggerParser._get_messages(event)
         message_ids = []
-        for record in event.get("Records", []):
-            record_message_id = record.get("messageId")
+        for record in messages:
+            record_message_id = record.get("messageId") or record.get("MessageId")
             if not record_message_id:
                 continue
             message_ids.append(record_message_id)
 
+        arn = event.get("Records", [{}])[0].get("eventSourceARN") or "Unknown"
         return EventTriggerParser.build_trigger(
             target_id=target_id,
             resource_type="sqs",
             from_message_ids=message_ids,
             extra={
-                ExtraKeys.ARN: event["Records"][0]["eventSourceARN"],
-                ExtraKeys.RECORDS_NUM: len(event["Records"]),
+                ExtraKeys.ARN: arn,
+                ExtraKeys.RECORDS_NUM: len(messages),
             },
         )
 
     @staticmethod
     def extract_inner(event: Dict[Any, Any]) -> List[str]:
         inner_messages = []
-        for record in event.get("Records", []):
-            body = record.get("body")
+        for record in SqsEventTriggerParser._get_messages(event):
+            body = record.get("body") or record.get("Body")
             if isinstance(body, str):
                 inner_messages.append(body)
         return inner_messages

--- a/src/lumigo_tracer/extension/extension.py
+++ b/src/lumigo_tracer/extension/extension.py
@@ -8,6 +8,7 @@ from lumigo_tracer.extension.extension_utils import get_current_bandwidth, get_e
 from lumigo_tracer import lumigo_utils
 from lumigo_tracer.extension.lambda_service import LambdaService
 from lumigo_tracer.extension.sampler import Sampler
+from lumigo_tracer.lambda_tracer import lambda_reporter
 from lumigo_tracer.lumigo_utils import lumigo_safe_execute
 
 SPAN_TYPE = "extensionExecutionEnd"
@@ -74,4 +75,4 @@ class LumigoExtension:
             cpuUsageTime=[s.dump() for s in self.sampler.get_cpu_samples()],
             memoryUsage=[s.dump() for s in self.sampler.get_memory_samples()],
         )
-        lumigo_utils.report_json(os.environ.get("AWS_REGION", "us-east-1"), msgs=[asdict(span)])
+        lambda_reporter.report_json(os.environ.get("AWS_REGION", "us-east-1"), msgs=[asdict(span)])

--- a/src/lumigo_tracer/lambda_tracer/global_scope_exec.py
+++ b/src/lumigo_tracer/lambda_tracer/global_scope_exec.py
@@ -1,0 +1,14 @@
+from lumigo_tracer import auto_instrument_handler
+from lumigo_tracer.lambda_tracer import lambda_reporter
+from lumigo_tracer.lumigo_utils import is_aws_environment
+from lumigo_tracer.wrappers import wrap
+
+
+def global_scope_exec() -> None:
+    if is_aws_environment():
+        # Connection to edge: build the session
+        lambda_reporter.establish_connection_global()
+        # auto_instrument: import handler during runtime initialization, as usual.
+        auto_instrument_handler.prefetch_handler_import()
+        # follow requests to third party services
+        wrap()

--- a/src/lumigo_tracer/lambda_tracer/global_scope_exec.py
+++ b/src/lumigo_tracer/lambda_tracer/global_scope_exec.py
@@ -1,7 +1,7 @@
 from lumigo_tracer import auto_instrument_handler
 from lumigo_tracer.lambda_tracer import lambda_reporter
 from lumigo_tracer.lumigo_utils import is_aws_environment
-from lumigo_tracer.wrappers import wrap
+from lumigo_tracer import wrappers
 
 
 def global_scope_exec() -> None:
@@ -11,4 +11,4 @@ def global_scope_exec() -> None:
         # auto_instrument: import handler during runtime initialization, as usual.
         auto_instrument_handler.prefetch_handler_import()
         # follow requests to third party services
-        wrap()
+        wrappers.wrap()

--- a/src/lumigo_tracer/lambda_tracer/lambda_reporter.py
+++ b/src/lumigo_tracer/lambda_tracer/lambda_reporter.py
@@ -1,0 +1,293 @@
+import os
+import uuid
+import time
+import random
+import socket
+import datetime
+import http.client
+from pathlib import Path
+from typing import Optional, List, Dict, Any, Union
+from base64 import b64encode
+from functools import lru_cache
+
+from lumigo_tracer.lumigo_utils import (
+    InternalState,
+    get_logger,
+    Configuration,
+    EDGE_HOST,
+    aws_dump,
+    internal_analytics_message,
+    lumigo_safe_execute,
+    warn_client,
+    should_use_tracer_extension,
+    is_span_has_error,
+    get_region,
+)
+
+try:
+    import botocore
+    import boto3
+except Exception:
+    botocore = None
+    boto3 = None
+
+EDGE_PATH = "/api/spans"
+HTTPS_PREFIX = "https://"
+SECONDS_TO_TIMEOUT = 0.5
+EDGE_TIMEOUT = float(os.environ.get("LUMIGO_EDGE_TIMEOUT", SECONDS_TO_TIMEOUT))
+MAX_SIZE_FOR_REQUEST: int = int(os.environ.get("LUMIGO_MAX_SIZE_FOR_REQUEST", 1024 * 500))
+MAX_NUMBER_OF_SPANS: int = int(os.environ.get("LUMIGO_MAX_NUMBER_OF_SPANS", 2000))
+TOO_BIG_SPANS_THRESHOLD = 5
+NUMBER_OF_SPANS_IN_REPORT_OPTIMIZATION = 200
+COOLDOWN_AFTER_TIMEOUT_DURATION = datetime.timedelta(seconds=10)
+CHINA_REGION = "cn-northwest-1"
+LUMIGO_SPANS_DIR = "/tmp/lumigo-spans"
+
+edge_kinesis_boto_client = None
+edge_connection = None
+
+
+def establish_connection_global() -> None:
+    global edge_connection
+    try:
+        # Try to establish the connection in initialization
+        if (
+            os.environ.get("LUMIGO_INITIALIZATION_CONNECTION", "").lower() != "false"
+            and get_region() != CHINA_REGION  # noqa
+        ):
+            edge_connection = establish_connection()
+            if edge_connection:
+                edge_connection.connect()
+    except socket.timeout:
+        InternalState.mark_timeout_to_edge()
+    except Exception:
+        pass
+
+
+def should_report_to_edge() -> bool:
+    if not InternalState.timeout_on_connection:
+        return True
+    time_diff = datetime.datetime.now() - InternalState.timeout_on_connection
+    return time_diff > COOLDOWN_AFTER_TIMEOUT_DURATION
+
+
+def establish_connection(host: Optional[str] = None) -> Optional[http.client.HTTPSConnection]:
+    try:
+        if not host:
+            host = get_edge_host(os.environ.get("AWS_REGION"))
+        return http.client.HTTPSConnection(host, timeout=EDGE_TIMEOUT)
+    except Exception as e:
+        get_logger().exception(f"Could not establish connection to {host}", exc_info=e)
+    return None
+
+
+@lru_cache(maxsize=1)
+def get_edge_host(region: Optional[str] = None) -> str:
+    host = Configuration.host or EDGE_HOST.format(region=region or get_region())
+    if host.startswith(HTTPS_PREFIX):
+        host = host[len(HTTPS_PREFIX) :]  # noqa: E203
+    if host.endswith(EDGE_PATH):
+        host = host[: -len(EDGE_PATH)]
+    return host
+
+
+def report_json(
+    region: Optional[str],
+    msgs: List[Dict[Any, Any]],
+    should_retry: bool = True,
+    is_start_span: bool = False,
+) -> int:
+    """
+    This function sends the information back to the edge.
+
+    :param region: The region to use as default if not configured otherwise.
+    :param msgs: the message to send.
+    :param should_retry: False to disable the default retry on unsuccessful sending
+    :param is_start_span: a flag to indicate if this is the start_span
+     of spans that will be written
+    :return: The duration of reporting (in milliseconds),
+                or 0 if we didn't send (due to configuration or fail).
+    """
+    if not should_report_to_edge():
+        get_logger().info("Skip sending messages due to previous timeout")
+        return 0
+    if not Configuration.should_report:
+        return 0
+    get_logger().info(f"reporting the messages: {msgs[:10]}")
+    try:
+        prune_trace: bool = not os.environ.get("LUMIGO_PRUNE_TRACE_OFF", "").lower() == "true"
+        to_send = _create_request_body(msgs, prune_trace).encode()
+    except Exception as e:
+        get_logger().exception("Failed to create request: A span was lost.", exc_info=e)
+        return 0
+    if should_use_tracer_extension():
+        with lumigo_safe_execute("report json file: writing spans to file"):
+            write_spans_to_files(spans=msgs, is_start_span=is_start_span)
+        return 0
+    if region == CHINA_REGION:
+        return _publish_spans_to_kinesis(to_send, CHINA_REGION)
+    host = None
+    global edge_connection
+    with lumigo_safe_execute("report json: establish connection"):
+        host = get_edge_host(region)
+        duration = 0
+        if not edge_connection or edge_connection.host != host:
+            edge_connection = establish_connection(host)
+            if not edge_connection:
+                get_logger().warning("Can not establish connection. Skip sending span.")
+                return duration
+    try:
+        start_time = time.time()
+        edge_connection.request(
+            "POST",
+            EDGE_PATH,
+            to_send,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": Configuration.token or "",
+            },
+        )
+        response = edge_connection.getresponse()
+        response.read()  # We must read the response to keep the connection available
+        duration = int((time.time() - start_time) * 1000)
+        get_logger().info(f"successful reporting, code: {getattr(response, 'code', 'unknown')}")
+    except socket.timeout:
+        get_logger().exception(f"Timeout while connecting to {host}")
+        InternalState.mark_timeout_to_edge()
+        internal_analytics_message("report: socket.timeout")
+    except Exception as e:
+        if should_retry:
+            get_logger().info(f"Could not report to {host}: ({str(e)}). Retrying.")
+            edge_connection = establish_connection(host)
+            report_json(region, msgs, should_retry=False)
+        else:
+            get_logger().exception("Could not report: A span was lost.", exc_info=e)
+            internal_analytics_message(f"report: {type(e)}")
+    return duration
+
+
+def _create_request_body(
+    msgs: List[dict],  # type: ignore[type-arg]
+    prune_size_flag: bool,
+    max_size: int = MAX_SIZE_FOR_REQUEST,
+    too_big_spans_threshold: int = TOO_BIG_SPANS_THRESHOLD,
+) -> str:
+
+    if not prune_size_flag or (
+        len(msgs) < NUMBER_OF_SPANS_IN_REPORT_OPTIMIZATION
+        and _get_event_base64_size(msgs) < max_size  # noqa
+    ):
+        return aws_dump(msgs)[:max_size]
+
+    end_span = msgs[-1]
+    ordered_spans = sorted(msgs[:-1], key=is_span_has_error, reverse=True)
+
+    spans_to_send: list = [end_span]  # type: ignore[type-arg]
+    current_size = _get_event_base64_size(end_span)
+    too_big_spans = 0
+    for span in ordered_spans:
+        span_size = _get_event_base64_size(span)
+        if current_size + span_size < max_size:
+            spans_to_send.append(span)
+            current_size += span_size
+        else:
+            # This is an optimization step. If the spans are too big, don't try to send them.
+            too_big_spans += 1
+            if too_big_spans == too_big_spans_threshold:
+                break
+    return aws_dump(spans_to_send)[:max_size]
+
+
+def write_spans_to_files(
+    spans: List[Dict[Any, Any]], max_spans: int = MAX_NUMBER_OF_SPANS, is_start_span: bool = True
+) -> None:
+    to_send = spans[:max_spans]
+    if is_start_span:
+        get_logger().info("Creating start span file")
+        write_extension_file(to_send, "span")
+    else:
+        get_logger().info("Creating end span file")
+        write_extension_file(to_send, "end")
+
+
+def write_extension_file(data: List[Dict], span_type: str):  # type: ignore[no-untyped-def,type-arg]
+    Path(get_extension_dir()).mkdir(parents=True, exist_ok=True)
+    to_send = aws_dump(data).encode()
+    file_path = get_span_file_name(span_type)
+    with open(file_path, "wb") as span_file:
+        span_file.write(to_send)
+        get_logger().info(f"Wrote span to file to [{file_path}][{len(to_send)}]")
+
+
+def get_extension_dir() -> str:
+    return (os.environ.get("LUMIGO_EXTENSION_SPANS_DIR_KEY") or LUMIGO_SPANS_DIR).lower()
+
+
+def get_span_file_name(span_type: str):  # type: ignore[no-untyped-def]
+    unique_name = str(uuid.uuid4())
+    return os.path.join(get_extension_dir(), f"{unique_name}_{span_type}")
+
+
+def _publish_spans_to_kinesis(to_send: bytes, region: str) -> int:
+    start_time = time.time()
+    try:
+        get_logger().info("Sending spans to Kinesis")
+        if not Configuration.edge_kinesis_aws_access_key_id:
+            get_logger().error("Missing edge_kinesis_aws_access_key_id, can't publish the spans")
+            return 0
+        if not Configuration.edge_kinesis_aws_secret_access_key:
+            get_logger().error(
+                "Missing edge_kinesis_aws_secret_access_key, can't publish the spans"
+            )
+            return 0
+        _send_data_to_kinesis(
+            stream_name=Configuration.edge_kinesis_stream_name,
+            to_send=to_send,
+            region=region,
+            aws_access_key_id=Configuration.edge_kinesis_aws_access_key_id,
+            aws_secret_access_key=Configuration.edge_kinesis_aws_secret_access_key,
+        )
+    except Exception as err:
+        get_logger().exception("Failed to send spans to Kinesis", exc_info=err)
+        warn_client(f"Failed to send spans to Kinesis: {err}")
+    return int((time.time() - start_time) * 1000)
+
+
+def _send_data_to_kinesis(  # type: ignore[no-untyped-def]
+    stream_name: str,
+    to_send: bytes,
+    region: str,
+    aws_access_key_id: str,
+    aws_secret_access_key: str,
+):
+    if not boto3:
+        get_logger().error("boto3 is missing. Unable to send to Kinesis.")
+        return None
+    client = _get_edge_kinesis_boto_client(
+        region=region,
+        aws_access_key_id=aws_access_key_id,
+        aws_secret_access_key=aws_secret_access_key,
+    )
+    client.put_record(Data=to_send, StreamName=stream_name, PartitionKey=str(random.random()))
+    get_logger().info("Successful sending to Kinesis")
+
+
+def _get_edge_kinesis_boto_client(region: str, aws_access_key_id: str, aws_secret_access_key: str):  # type: ignore[no-untyped-def]
+    global edge_kinesis_boto_client
+    if not edge_kinesis_boto_client or _is_edge_kinesis_connection_cache_disabled():
+        edge_kinesis_boto_client = boto3.client(
+            "kinesis",
+            region_name=region,
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            config=botocore.config.Config(retries={"max_attempts": 1, "mode": "standard"}),
+        )
+    return edge_kinesis_boto_client
+
+
+def _is_edge_kinesis_connection_cache_disabled() -> bool:
+    return os.environ.get("LUMIGO_KINESIS_SHOULD_REUSE_CONNECTION", "").lower() == "false"
+
+
+def _get_event_base64_size(event: Union[Dict[Any, Any], List[Dict[Any, Any]]]) -> int:
+    return len(b64encode(aws_dump(event).encode()))

--- a/src/lumigo_tracer/lambda_tracer/tracer.py
+++ b/src/lumigo_tracer/lambda_tracer/tracer.py
@@ -9,8 +9,7 @@ from lumigo_tracer.lumigo_utils import (
     is_aws_environment,
     is_kill_switch_on,
 )
-from lumigo_tracer.spans_container import SpansContainer, TimeoutMechanism
-from lumigo_tracer.wrappers import wrap
+from lumigo_tracer.lambda_tracer.spans_container import SpansContainer, TimeoutMechanism
 
 CONTEXT_WRAPPED_BY_LUMIGO_KEY = "_wrapped_by_lumigo"
 
@@ -37,7 +36,6 @@ def _add_wrap_flag_to_context(*args):  # type: ignore[no-untyped-def]
 def _lumigo_tracer(func):  # type: ignore[no-untyped-def]
     if is_kill_switch_on():
         return func
-    wrap()
 
     @wraps(func)
     def lambda_wrapper(*args, **kwargs):  # type: ignore[no-untyped-def]

--- a/src/lumigo_tracer/lumigo_utils.py
+++ b/src/lumigo_tracer/lumigo_utils.py
@@ -3,8 +3,6 @@ import re
 import uuid
 import time
 import json
-import random
-import socket
 import base64
 import logging
 import decimal
@@ -12,39 +10,20 @@ import hashlib
 import inspect
 import datetime
 import traceback
-import http.client
-from pathlib import Path
-from base64 import b64encode
 from collections import OrderedDict
 from contextlib import contextmanager
 from functools import reduce, lru_cache
 from typing import Union, List, Optional, Dict, Any, Tuple, Pattern, TypeVar
 
 LUMIGO_DOMAINS_SCRUBBER_KEY = "LUMIGO_DOMAINS_SCRUBBER"
-
-try:
-    import botocore
-    import boto3
-except Exception:
-    botocore = None
-    boto3 = None
-
 EXECUTION_TAGS_KEY = "lumigo_execution_tags_no_scrub"
 MANUAL_TRACES_KEY = "manualTraces"
 EDGE_SUFFIX = "golumigo.com"
 EDGE_HOST = "{region}.lumigo-tracer-edge." + EDGE_SUFFIX
-EDGE_PATH = "/api/spans"
-HTTPS_PREFIX = "https://"
 LOG_FORMAT = "#LUMIGO# - %(levelname)s - %(asctime)s - %(message)s"
-SECONDS_TO_TIMEOUT = 0.5
-COOLDOWN_AFTER_TIMEOUT_DURATION = datetime.timedelta(seconds=10)
 LUMIGO_EVENT_KEY = "_lumigo"
 STEP_FUNCTION_UID_KEY = "step_function_uid"
 # number of spans that are too big to enter the reported message before break
-TOO_BIG_SPANS_THRESHOLD = 5
-MAX_SIZE_FOR_REQUEST: int = int(os.environ.get("LUMIGO_MAX_SIZE_FOR_REQUEST", 1024 * 500))
-MAX_NUMBER_OF_SPANS: int = int(os.environ.get("LUMIGO_MAX_NUMBER_OF_SPANS", 2000))
-EDGE_TIMEOUT = float(os.environ.get("LUMIGO_EDGE_TIMEOUT", SECONDS_TO_TIMEOUT))
 MAX_VARS_SIZE = 100_000
 MAX_VAR_LEN = 1024
 DEFAULT_MAX_ENTRY_SIZE = 2048
@@ -73,16 +52,13 @@ LUMIGO_PROPAGATE_W3C = "LUMIGO_PROPAGATE_W3C"
 WARN_CLIENT_PREFIX = "Lumigo Warning"
 INTERNAL_ANALYTICS_PREFIX = "Lumigo Analytic Log"
 TRUNCATE_SUFFIX = "...[too long]"
-NUMBER_OF_SPANS_IN_REPORT_OPTIMIZATION = 200
 DEFAULT_KEY_DEPTH = 4
 LUMIGO_TOKEN_KEY = "LUMIGO_TRACER_TOKEN"
 LUMIGO_USE_TRACER_EXTENSION = "LUMIGO_USE_TRACER_EXTENSION"
-LUMIGO_SPANS_DIR = "/tmp/lumigo-spans"
 KILL_SWITCH = "LUMIGO_SWITCH_OFF"
 ERROR_SIZE_LIMIT_MULTIPLIER = 2
-CHINA_REGION = "cn-northwest-1"
 EDGE_KINESIS_STREAM_NAME = "prod_trc-inges-edge_edge-kinesis-stream"
-STACKTRACE_LINE_TO_DROP = "lumigo_tracer/tracer.py"
+STACKTRACE_LINE_TO_DROP = "lumigo_tracer/lambda_tracer/tracer.py"
 Container = TypeVar("Container", dict, list)  # type: ignore[type-arg,type-arg]
 DEFAULT_AUTO_TAG_KEY = "LUMIGO_AUTO_TAG"
 SKIP_COLLECTING_HTTP_BODY_KEY = "LUMIGO_SKIP_COLLECTING_HTTP_BODY"
@@ -93,16 +69,9 @@ DEFAULT_CHAINED_SERVICES_MAX_WIDTH = 5
 
 _logger: Dict[str, logging.Logger] = {}
 
-edge_kinesis_boto_client = None
-edge_connection = None
-
 
 def should_use_tracer_extension() -> bool:
     return (os.environ.get(LUMIGO_USE_TRACER_EXTENSION) or "false").lower() == "true"
-
-
-def get_extension_dir() -> str:
-    return (os.environ.get("LUMIGO_EXTENSION_SPANS_DIR_KEY") or LUMIGO_SPANS_DIR).lower()
 
 
 def get_region() -> str:
@@ -121,13 +90,6 @@ class InternalState:
     @staticmethod
     def mark_timeout_to_edge():  # type: ignore[no-untyped-def]
         InternalState.timeout_on_connection = datetime.datetime.now()
-
-    @staticmethod
-    def should_report_to_edge() -> bool:
-        if not InternalState.timeout_on_connection:
-            return True
-        time_diff = datetime.datetime.now() - InternalState.timeout_on_connection
-        return time_diff > COOLDOWN_AFTER_TIMEOUT_DURATION
 
 
 class Configuration:
@@ -280,225 +242,13 @@ def config(
     )
 
 
-def _is_span_has_error(span: dict) -> bool:  # type: ignore[type-arg]
+def is_span_has_error(span: dict) -> bool:  # type: ignore[type-arg]
     return (
         span.get("error") is not None  # noqa
         or span.get("info", {}).get("httpInfo", {}).get("response", {}).get("statusCode", 0)  # noqa
         > 400  # noqa
         or span.get("returnValue", {}).get("statusCode", 0) > 400  # noqa
     )
-
-
-def _get_event_base64_size(event) -> int:  # type: ignore[no-untyped-def]
-    return len(b64encode(aws_dump(event).encode()))
-
-
-def _create_request_body(
-    msgs: List[dict],  # type: ignore[type-arg]
-    prune_size_flag: bool,
-    max_size: int = MAX_SIZE_FOR_REQUEST,
-    too_big_spans_threshold: int = TOO_BIG_SPANS_THRESHOLD,
-) -> str:
-
-    if not prune_size_flag or (
-        len(msgs) < NUMBER_OF_SPANS_IN_REPORT_OPTIMIZATION
-        and _get_event_base64_size(msgs) < max_size  # noqa
-    ):
-        return aws_dump(msgs)[:max_size]
-
-    end_span = msgs[-1]
-    ordered_spans = sorted(msgs[:-1], key=_is_span_has_error, reverse=True)
-
-    spans_to_send: list = [end_span]  # type: ignore[type-arg]
-    current_size = _get_event_base64_size(end_span)
-    too_big_spans = 0
-    for span in ordered_spans:
-        span_size = _get_event_base64_size(span)
-        if current_size + span_size < max_size:
-            spans_to_send.append(span)
-            current_size += span_size
-        else:
-            # This is an optimization step. If the spans are too big, don't try to send them.
-            too_big_spans += 1
-            if too_big_spans == too_big_spans_threshold:
-                break
-    return aws_dump(spans_to_send)[:max_size]
-
-
-def establish_connection(host=None):  # type: ignore[no-untyped-def]
-    try:
-        if not host:
-            host = get_edge_host(os.environ.get("AWS_REGION"))
-        return http.client.HTTPSConnection(host, timeout=EDGE_TIMEOUT)
-    except Exception as e:
-        get_logger().exception(f"Could not establish connection to {host}", exc_info=e)
-    return None
-
-
-@lru_cache(maxsize=1)
-def get_edge_host(region: Optional[str] = None) -> str:
-    host = Configuration.host or EDGE_HOST.format(region=region or get_region())
-    if host.startswith(HTTPS_PREFIX):
-        host = host[len(HTTPS_PREFIX) :]  # noqa: E203
-    if host.endswith(EDGE_PATH):
-        host = host[: -len(EDGE_PATH)]
-    return host
-
-
-def report_json(  # type: ignore[no-untyped-def]
-    region: Optional[str], msgs: List[dict], should_retry: bool = True, is_start_span=False  # type: ignore[type-arg]
-) -> int:
-    """
-    This function sends the information back to the edge.
-
-    :param region: The region to use as default if not configured otherwise.
-    :param msgs: the message to send.
-    :param should_retry: False to disable the default retry on unsuccessful sending
-    :param is_start_span: a flag to indicate if this is the start_span
-     of spans that will be written
-    :return: The duration of reporting (in milliseconds),
-                or 0 if we didn't send (due to configuration or fail).
-    """
-    if not InternalState.should_report_to_edge():
-        get_logger().info("Skip sending messages due to previous timeout")
-        return 0
-    if not Configuration.should_report:
-        return 0
-    get_logger().info(f"reporting the messages: {msgs[:10]}")
-    try:
-        prune_trace: bool = not os.environ.get("LUMIGO_PRUNE_TRACE_OFF", "").lower() == "true"
-        to_send = _create_request_body(msgs, prune_trace).encode()
-    except Exception as e:
-        get_logger().exception("Failed to create request: A span was lost.", exc_info=e)
-        return 0
-    if should_use_tracer_extension():
-        with lumigo_safe_execute("report json file: writing spans to file"):
-            write_spans_to_files(spans=msgs, is_start_span=is_start_span)
-        return 0
-    if region == CHINA_REGION:
-        return _publish_spans_to_kinesis(to_send, CHINA_REGION)
-    host = None
-    global edge_connection
-    with lumigo_safe_execute("report json: establish connection"):
-        host = get_edge_host(region)
-        duration = 0
-        if not edge_connection or edge_connection.host != host:
-            edge_connection = establish_connection(host)
-            if not edge_connection:
-                get_logger().warning("Can not establish connection. Skip sending span.")
-                return duration
-    try:
-        start_time = time.time()
-        edge_connection.request(
-            "POST",
-            EDGE_PATH,
-            to_send,
-            headers={"Content-Type": "application/json", "Authorization": Configuration.token},
-        )
-        response = edge_connection.getresponse()
-        response.read()  # We must read the response to keep the connection available
-        duration = int((time.time() - start_time) * 1000)
-        get_logger().info(f"successful reporting, code: {getattr(response, 'code', 'unknown')}")
-    except socket.timeout:
-        get_logger().exception(f"Timeout while connecting to {host}")
-        InternalState.mark_timeout_to_edge()
-        internal_analytics_message("report: socket.timeout")
-    except Exception as e:
-        if should_retry:
-            get_logger().info(f"Could not report to {host}: ({str(e)}). Retrying.")
-            edge_connection = establish_connection(host)
-            report_json(region, msgs, should_retry=False)
-        else:
-            get_logger().exception("Could not report: A span was lost.", exc_info=e)
-            internal_analytics_message(f"report: {type(e)}")
-    return duration
-
-
-def get_span_file_name(span_type: str):  # type: ignore[no-untyped-def]
-    unique_name = str(uuid.uuid4())
-    return os.path.join(get_extension_dir(), f"{unique_name}_{span_type}")
-
-
-def write_extension_file(data: List[Dict], span_type: str):  # type: ignore[no-untyped-def,type-arg]
-    Path(get_extension_dir()).mkdir(parents=True, exist_ok=True)
-    to_send = aws_dump(data).encode()
-    file_path = get_span_file_name(span_type)
-    with open(file_path, "wb") as span_file:
-        span_file.write(to_send)
-        get_logger().info(f"Wrote span to file to [{file_path}][{len(to_send)}]")
-
-
-def write_spans_to_files(  # type: ignore[no-untyped-def]
-    spans: List[Dict], max_spans=MAX_NUMBER_OF_SPANS, is_start_span=True  # type: ignore[type-arg]
-) -> None:
-    to_send = spans[:max_spans]
-    if is_start_span:
-        get_logger().info("Creating start span file")
-        write_extension_file(to_send, "span")
-    else:
-        get_logger().info("Creating end span file")
-        write_extension_file(to_send, "end")
-
-
-def _publish_spans_to_kinesis(to_send: bytes, region: str) -> int:
-    start_time = time.time()
-    try:
-        get_logger().info("Sending spans to Kinesis")
-        if not Configuration.edge_kinesis_aws_access_key_id:
-            get_logger().error("Missing edge_kinesis_aws_access_key_id, can't publish the spans")
-            return 0
-        if not Configuration.edge_kinesis_aws_secret_access_key:
-            get_logger().error(
-                "Missing edge_kinesis_aws_secret_access_key, can't publish the spans"
-            )
-            return 0
-        _send_data_to_kinesis(
-            stream_name=Configuration.edge_kinesis_stream_name,
-            to_send=to_send,
-            region=region,
-            aws_access_key_id=Configuration.edge_kinesis_aws_access_key_id,
-            aws_secret_access_key=Configuration.edge_kinesis_aws_secret_access_key,
-        )
-    except Exception as err:
-        get_logger().exception("Failed to send spans to Kinesis", exc_info=err)
-        warn_client(f"Failed to send spans to Kinesis: {err}")
-    return int((time.time() - start_time) * 1000)
-
-
-def _is_edge_kinesis_connection_cache_disabled() -> bool:
-    return os.environ.get("LUMIGO_KINESIS_SHOULD_REUSE_CONNECTION", "").lower() == "false"
-
-
-def _get_edge_kinesis_boto_client(region: str, aws_access_key_id: str, aws_secret_access_key: str):  # type: ignore[no-untyped-def]
-    global edge_kinesis_boto_client
-    if not edge_kinesis_boto_client or _is_edge_kinesis_connection_cache_disabled():
-        edge_kinesis_boto_client = boto3.client(
-            "kinesis",
-            region_name=region,
-            aws_access_key_id=aws_access_key_id,
-            aws_secret_access_key=aws_secret_access_key,
-            config=botocore.config.Config(retries={"max_attempts": 1, "mode": "standard"}),
-        )
-    return edge_kinesis_boto_client
-
-
-def _send_data_to_kinesis(  # type: ignore[no-untyped-def]
-    stream_name: str,
-    to_send: bytes,
-    region: str,
-    aws_access_key_id: str,
-    aws_secret_access_key: str,
-):
-    if not boto3:
-        get_logger().error("boto3 is missing. Unable to send to Kinesis.")
-        return None
-    client = _get_edge_kinesis_boto_client(
-        region=region,
-        aws_access_key_id=aws_access_key_id,
-        aws_secret_access_key=aws_secret_access_key,
-    )
-    client.put_record(Data=to_send, StreamName=stream_name, PartitionKey=str(random.random()))
-    get_logger().info("Successful sending to Kinesis")
 
 
 def get_logger(logger_name="lumigo"):  # type: ignore[no-untyped-def]
@@ -533,7 +283,7 @@ def lumigo_safe_execute(part_name="", severity=logging.ERROR):  # type: ignore[n
         )
 
 
-def is_aws_environment():  # type: ignore[no-untyped-def]
+def is_aws_environment() -> bool:
     """
     :return: heuristically determine rather we're running on an aws environment.
     """
@@ -858,20 +608,6 @@ def get_stacktrace(exception: Exception) -> str:
 
 def is_python_37() -> bool:
     return os.environ.get("AWS_EXECUTION_ENV") == "AWS_Lambda_python3.7"
-
-
-try:
-    # Try to establish the connection in initialization
-    if (
-        os.environ.get("LUMIGO_INITIALIZATION_CONNECTION", "").lower() != "false"
-        and get_region() != CHINA_REGION  # noqa
-    ):
-        edge_connection = establish_connection()
-        edge_connection.connect()
-except socket.timeout:
-    InternalState.mark_timeout_to_edge()
-except Exception:
-    pass
 
 
 def is_lambda_traced() -> bool:

--- a/src/lumigo_tracer/user_utils.py
+++ b/src/lumigo_tracer/user_utils.py
@@ -3,7 +3,7 @@ import logging
 from contextlib import contextmanager
 from typing import Dict, Optional
 
-from lumigo_tracer.spans_container import SpansContainer
+from lumigo_tracer.lambda_tracer.spans_container import SpansContainer
 from lumigo_tracer.lumigo_utils import warn_client, is_lambda_traced
 
 LUMIGO_REPORT_ERROR_STRING = "[LUMIGO_LOG]"

--- a/src/lumigo_tracer/wrappers/__init__.py
+++ b/src/lumigo_tracer/wrappers/__init__.py
@@ -3,12 +3,14 @@ from .pymongo.pymongo_wrapper import wrap_pymongo
 from .redis.redis_wrapper import wrap_redis
 from .sql.sqlalchemy_wrapper import wrap_sqlalchemy
 from .aiohttp.aiohttp_wrapper import wrap_aiohttp
-
+from ..lumigo_utils import is_aws_environment
 
 already_wrapped = False
 
 
-def wrap(force: bool = False):  # type: ignore[no-untyped-def]
+def wrap(force: bool = False) -> None:
+    if not is_aws_environment():
+        return
     global already_wrapped
     if not already_wrapped:
         # Never wrap http calls twice - it will create duplicate body

--- a/src/lumigo_tracer/wrappers/aiohttp/aiohttp_wrapper.py
+++ b/src/lumigo_tracer/wrappers/aiohttp/aiohttp_wrapper.py
@@ -1,6 +1,6 @@
 from lumigo_tracer.lumigo_utils import lumigo_safe_execute, get_logger, concat_old_body_to_new
 from lumigo_tracer.libs.wrapt import wrap_function_wrapper
-from lumigo_tracer.spans_container import SpansContainer
+from lumigo_tracer.lambda_tracer.spans_container import SpansContainer
 from lumigo_tracer.wrappers.http.http_data_classes import HttpRequest
 from lumigo_tracer.wrappers.http.sync_http_wrappers import add_request_event, update_event_response
 

--- a/src/lumigo_tracer/wrappers/http/sync_http_wrappers.py
+++ b/src/lumigo_tracer/wrappers/http/sync_http_wrappers.py
@@ -7,11 +7,12 @@ import http.client
 import logging
 import random
 
+from lumigo_tracer.lambda_tracer.lambda_reporter import get_edge_host
 from lumigo_tracer.wrappers.http.http_data_classes import HttpRequest, HttpState
 from lumigo_tracer.parsing_utils import safe_get_list, recursive_json_join
 from lumigo_tracer.wrappers.http.http_parser import get_parser, HTTP_TYPE
 from lumigo_tracer.libs.wrapt import wrap_function_wrapper
-from lumigo_tracer.spans_container import SpansContainer
+from lumigo_tracer.lambda_tracer.spans_container import SpansContainer
 from lumigo_tracer.lumigo_utils import (
     get_logger,
     lumigo_safe_execute,
@@ -20,7 +21,6 @@ from lumigo_tracer.lumigo_utils import (
     lumigo_dumps,
     get_size_upper_bound,
     is_error_code,
-    get_edge_host,
     TRUNCATE_SUFFIX,
     concat_old_body_to_new,
     EDGE_SUFFIX,

--- a/src/lumigo_tracer/wrappers/pymongo/pymongo_wrapper.py
+++ b/src/lumigo_tracer/wrappers/pymongo/pymongo_wrapper.py
@@ -7,7 +7,7 @@ from lumigo_tracer.lumigo_utils import (
     lumigo_dumps,
     get_current_ms_time,
 )
-from lumigo_tracer.spans_container import SpansContainer
+from lumigo_tracer.lambda_tracer.spans_container import SpansContainer
 
 try:
     from pymongo import monitoring

--- a/src/lumigo_tracer/wrappers/redis/redis_wrapper.py
+++ b/src/lumigo_tracer/wrappers/redis/redis_wrapper.py
@@ -10,7 +10,7 @@ from lumigo_tracer.lumigo_utils import (
     lumigo_dumps,
     get_current_ms_time,
 )
-from lumigo_tracer.spans_container import SpansContainer
+from lumigo_tracer.lambda_tracer.spans_container import SpansContainer
 
 
 REDIS_SPAN = "redis"

--- a/src/lumigo_tracer/wrappers/sql/sqlalchemy_wrapper.py
+++ b/src/lumigo_tracer/wrappers/sql/sqlalchemy_wrapper.py
@@ -10,7 +10,7 @@ from lumigo_tracer.lumigo_utils import (
     lumigo_dumps,
     get_current_ms_time,
 )
-from lumigo_tracer.spans_container import SpansContainer
+from lumigo_tracer.lambda_tracer.spans_container import SpansContainer
 
 try:
     from sqlalchemy.event import listen

--- a/src/test/component/test_component.py
+++ b/src/test/component/test_component.py
@@ -5,9 +5,9 @@ import pytest
 import subprocess
 import http.client
 
-from lumigo_tracer.tracer import lumigo_tracer
+from lumigo_tracer.lambda_tracer.tracer import lumigo_tracer
 from lumigo_tracer.lumigo_utils import md5hash
-from lumigo_tracer.spans_container import SpansContainer
+from lumigo_tracer.lambda_tracer.spans_container import SpansContainer
 
 TOKEN = "t_10faa5e13e7844aaa1234"
 
@@ -22,7 +22,7 @@ def serverless_yaml():
 
 
 @pytest.fixture(autouse=True)
-def aws_env_variables(monkeypatch):
+def aws_env_variables(monkeypatch, aws_environment):
     """
     When running in AWS Lambda, there are some environment variables that AWS creates and the tracer uses.
     This fixture creates those environment variables.

--- a/src/test/component/test_component.py
+++ b/src/test/component/test_component.py
@@ -5,6 +5,7 @@ import pytest
 import subprocess
 import http.client
 
+from lumigo_tracer import global_scope_exec
 from lumigo_tracer.lambda_tracer.tracer import lumigo_tracer
 from lumigo_tracer.lumigo_utils import md5hash
 from lumigo_tracer.lambda_tracer.spans_container import SpansContainer
@@ -31,6 +32,7 @@ def aws_env_variables(monkeypatch, aws_environment):
         "_X_AMZN_TRACE_ID",
         "RequestId: 4365921c-fc6d-4745-9f00-9fe9c516ede5 Root=1-000044d4-c3881e0c19c02c5e6ffa8f9e;Parent=37cf579525dfb3ba;Sampled=0",
     )
+    global_scope_exec()
 
 
 @pytest.fixture

--- a/src/test/unit/auto_tag/test_auto_tag_event.py
+++ b/src/test/unit/auto_tag/test_auto_tag_event.py
@@ -8,7 +8,7 @@ from lumigo_tracer.auto_tag.auto_tag_event import (
     AutoTagEvent,
     ConfigurationHandler,
 )
-from lumigo_tracer.spans_container import SpansContainer
+from lumigo_tracer.lambda_tracer.spans_container import SpansContainer
 from lumigo_tracer.lumigo_utils import Configuration
 
 

--- a/src/test/unit/event/test_event_trigger.py
+++ b/src/test/unit/event/test_event_trigger.py
@@ -238,6 +238,51 @@ from lumigo_tracer.lumigo_utils import Configuration
                 },
             ],
         ),
+        (  # SNS-SQS example trigger (ReceiveMessage)
+            {
+                "service_name": "sqs",
+                "operation_name": "ReceiveMessage",
+                "Messages": [
+                    {
+                        "MessageId": "aaaa-aaaa-aaaa-aaaa",
+                        "ReceiptHandle": "ReceiptHandle",
+                        "MD5OfBody": "123456789",
+                        "Body": '{\n  "Type" : "Notification",\n  "MessageId" : "bbbb-bbbb-bbbb-bbbb",\n  "TopicArn" : "arn:aws:sns:us-west-2:1234567891011:inner-sns",\n  "Message" : "{}",\n  "Timestamp" : "2023-01-22T09:43:08.651Z",\n  "SignatureVersion" : "1",\n  "Signature" : "Signature",\n  "SigningCertURL" : "https://sns.us-west-2.amazonaws.com/SimpleNotificationService-123456789.pem",\n  "UnsubscribeURL" : "https://sns.us-west-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-west-2:1234567891011:inner-sns-bbb-ccc"\n}',
+                    }
+                ],
+                "ResponseMetadata": {
+                    "RequestId": "RequestId",
+                    "HTTPStatusCode": 200,
+                    "HTTPHeaders": {
+                        "x-amzn-requestid": "x-amzn-requestid",
+                        "date": "Sun, 22 Jan 2023 09:44:25 GMT",
+                        "content-type": "text/xml",
+                        "content-length": "1998",
+                    },
+                    "RetryAttempts": 0,
+                },
+            },
+            [
+                {
+                    "extra": {
+                        "arn": "Unknown",
+                        "recordsNum": 1,
+                    },
+                    "fromMessageIds": [
+                        "aaaa-aaaa-aaaa-aaaa",
+                    ],
+                    "triggeredBy": "sqs",
+                },
+                {
+                    "extra": {
+                        "arn": "arn:aws:sns:us-west-2:1234567891011:inner-sns",
+                        "recordsNum": 1,
+                    },
+                    "fromMessageIds": ["bbbb-bbbb-bbbb-bbbb"],
+                    "triggeredBy": "sns",
+                },
+            ],
+        ),
         (  # SQS that is *not* SNS-SQS (not SimpleNotificationService)
             {
                 "Records": [

--- a/src/test/unit/lambda_tracer/test_global_scope_exec.py
+++ b/src/test/unit/lambda_tracer/test_global_scope_exec.py
@@ -1,18 +1,14 @@
 from lumigo_tracer.lambda_tracer.global_scope_exec import global_scope_exec
 from lumigo_tracer.lambda_tracer import lambda_reporter
-from lumigo_tracer import wrappers
 
 
 def test_global_scope_preparation_called_only_in_lambda(monkeypatch):
     lambda_reporter.edge_connection = None
-    wrappers.already_wrapped = False
 
     monkeypatch.delenv("AWS_LAMBDA_FUNCTION_VERSION", raising=False)
     global_scope_exec()
     assert lambda_reporter.edge_connection is None
-    assert not wrappers.already_wrapped
 
     monkeypatch.setenv("AWS_LAMBDA_FUNCTION_VERSION", "true")
     global_scope_exec()
     assert lambda_reporter.edge_connection is not None
-    assert wrappers.already_wrapped

--- a/src/test/unit/lambda_tracer/test_global_scope_exec.py
+++ b/src/test/unit/lambda_tracer/test_global_scope_exec.py
@@ -1,0 +1,18 @@
+from lumigo_tracer.lambda_tracer.global_scope_exec import global_scope_exec
+from lumigo_tracer.lambda_tracer import lambda_reporter
+from lumigo_tracer import wrappers
+
+
+def test_global_scope_preparation_called_only_in_lambda(monkeypatch):
+    lambda_reporter.edge_connection = None
+    wrappers.already_wrapped = False
+
+    monkeypatch.delenv("AWS_LAMBDA_FUNCTION_VERSION", raising=False)
+    global_scope_exec()
+    assert lambda_reporter.edge_connection is None
+    assert not wrappers.already_wrapped
+
+    monkeypatch.setenv("AWS_LAMBDA_FUNCTION_VERSION", "true")
+    global_scope_exec()
+    assert lambda_reporter.edge_connection is not None
+    assert wrappers.already_wrapped

--- a/src/test/unit/lambda_tracer/test_lambda_reporter.py
+++ b/src/test/unit/lambda_tracer/test_lambda_reporter.py
@@ -1,0 +1,234 @@
+import os
+import uuid
+import json
+import socket
+import logging
+import datetime
+import http.client
+import importlib.util
+from unittest.mock import Mock
+
+import boto3
+from mock import MagicMock
+import pytest
+
+from lumigo_tracer import lumigo_utils
+from lumigo_tracer.lambda_tracer import lambda_reporter
+from lumigo_tracer.lambda_tracer.lambda_reporter import (
+    _create_request_body,
+    _get_event_base64_size,
+    EDGE_PATH,
+    get_edge_host,
+    report_json,
+    CHINA_REGION,
+    get_extension_dir,
+    establish_connection,
+)
+from lumigo_tracer.lumigo_utils import (
+    Configuration,
+    InternalState,
+)
+
+
+@pytest.fixture
+def dummy_span():
+    return {"dummy": "dummy"}
+
+
+@pytest.fixture
+def function_end_span():
+    return {"dummy_end": "dummy_end"}
+
+
+@pytest.fixture
+def error_span():
+    return {"dummy": "dummy", "error": "Error"}
+
+
+def test_create_request_body_default(dummy_span):
+    assert _create_request_body([dummy_span], False) == json.dumps([dummy_span])
+
+
+def test_create_request_body_not_effecting_small_events(dummy_span):
+    assert _create_request_body([dummy_span], True, 1_000_000) == json.dumps([dummy_span])
+
+
+def test_create_request_body_keep_function_span_and_filter_other_spans(
+    dummy_span, function_end_span
+):
+    expected_result = [dummy_span, dummy_span, dummy_span, function_end_span]
+    size = _get_event_base64_size(expected_result)
+    assert _create_request_body(expected_result * 2, True, size) == json.dumps(
+        [function_end_span, dummy_span, dummy_span, dummy_span]
+    )
+
+
+def test_create_request_body_take_error_first(dummy_span, error_span, function_end_span):
+    expected_result = [function_end_span, error_span, dummy_span, dummy_span]
+    input = [
+        dummy_span,
+        dummy_span,
+        dummy_span,
+        dummy_span,
+        dummy_span,
+        error_span,
+        function_end_span,
+    ]
+    size = _get_event_base64_size(expected_result)
+    assert _create_request_body(input, True, size) == json.dumps(expected_result)
+
+
+@pytest.mark.parametrize(
+    ["arg", "host"],
+    [("https://a.com", "a.com"), (f"https://b.com{EDGE_PATH}", "b.com"), ("h.com", "h.com")],
+)
+def test_get_edge_host(arg, host, monkeypatch):
+    monkeypatch.setattr(Configuration, "host", arg)
+    assert get_edge_host("region") == host
+
+
+def test_report_json_extension_spans_mode(monkeypatch, reporter_mock, tmpdir):
+    extension_dir = tmpdir.mkdir("tmp")
+    monkeypatch.setattr(uuid, "uuid4", lambda *args, **kwargs: "span_name")
+    monkeypatch.setattr(Configuration, "should_report", True)
+    monkeypatch.setenv("LUMIGO_USE_TRACER_EXTENSION", "TRUE")
+    monkeypatch.setenv("LUMIGO_EXTENSION_SPANS_DIR_KEY", extension_dir)
+    mocked_urandom = MagicMock(hex=MagicMock(return_value="my_mocked_data"))
+    monkeypatch.setattr(os, "urandom", lambda *args, **kwargs: mocked_urandom)
+
+    start_span = [{"span": "true"}]
+    report_json(region=None, msgs=start_span, is_start_span=True)
+
+    spans = []
+    size_factor = 100
+    for i in range(size_factor):
+        spans.append(
+            {
+                i: "a" * size_factor,
+            }
+        )
+    report_json(region=None, msgs=spans, is_start_span=False)
+    start_path_path = f"{get_extension_dir()}/span_name_span"
+    end_path_path = f"{get_extension_dir()}/span_name_end"
+    start_file_content = json.loads(open(start_path_path, "r").read())
+    end_file_content = json.loads(open(end_path_path, "r").read())
+    assert start_span == start_file_content
+    assert json.dumps(end_file_content) == json.dumps(spans)
+
+
+@pytest.mark.parametrize(
+    "errors, final_log", [(ValueError, "ERROR"), ([ValueError, Mock()], "INFO")]
+)
+def test_report_json_retry(monkeypatch, reporter_mock, caplog, errors, final_log):
+    reporter_mock.side_effect = report_json
+    monkeypatch.setattr(Configuration, "host", "force_reconnect")
+    monkeypatch.setattr(Configuration, "should_report", True)
+    monkeypatch.setattr(http.client, "HTTPSConnection", Mock())
+    http.client.HTTPSConnection("force_reconnect").getresponse.side_effect = errors
+
+    report_json(None, [{"a": "b"}])
+
+    assert caplog.records[-1].levelname == final_log
+
+
+def test_report_json_fast_failure_after_timeout(monkeypatch, reporter_mock, caplog):
+    reporter_mock.side_effect = report_json
+    monkeypatch.setattr(Configuration, "host", "host")
+    monkeypatch.setattr(Configuration, "should_report", True)
+    monkeypatch.setattr(http.client, "HTTPSConnection", Mock())
+    http.client.HTTPSConnection("force_reconnect").getresponse.side_effect = socket.timeout
+
+    assert report_json(None, [{"a": "b"}]) == 0
+    assert caplog.records[-1].msg == "Timeout while connecting to host"
+
+    assert report_json(None, [{"a": "b"}]) == 0
+    assert caplog.records[-1].msg == "Skip sending messages due to previous timeout"
+
+    InternalState.timeout_on_connection = datetime.datetime(2016, 1, 1)
+    assert report_json(None, [{"a": "b"}]) == 0
+    assert caplog.records[-1].msg == "Timeout while connecting to host"
+
+
+def test_report_json_china_missing_access_key_id(monkeypatch, reporter_mock, caplog):
+    monkeypatch.setattr(Configuration, "should_report", True)
+    reporter_mock.side_effect = report_json
+    assert report_json(CHINA_REGION, [{"a": "b"}]) == 0
+    assert any(
+        "edge_kinesis_aws_access_key_id" in record.message and record.levelname == "ERROR"
+        for record in caplog.records
+    )
+
+
+def test_report_json_china_missing_secret_access_key(monkeypatch, reporter_mock, caplog):
+    monkeypatch.setattr(Configuration, "should_report", True)
+    monkeypatch.setattr(Configuration, "edge_kinesis_aws_access_key_id", "my_value")
+    reporter_mock.side_effect = report_json
+    assert report_json(CHINA_REGION, [{"a": "b"}]) == 0
+    assert any(
+        "edge_kinesis_aws_secret_access_key" in record.message and record.levelname == "ERROR"
+        for record in caplog.records
+    )
+
+
+def test_report_json_china_no_boto(monkeypatch, reporter_mock, caplog):
+    reporter_mock.side_effect = report_json
+    monkeypatch.setattr(Configuration, "should_report", True)
+    monkeypatch.setattr(Configuration, "edge_kinesis_aws_access_key_id", "my_value")
+    monkeypatch.setattr(Configuration, "edge_kinesis_aws_secret_access_key", "my_value")
+    monkeypatch.setattr(lambda_reporter, "boto3", None)
+
+    report_json(CHINA_REGION, [{"a": "b"}])
+
+    assert any(
+        "boto3 is missing. Unable to send to Kinesis" in record.message
+        and record.levelname == "ERROR"  # noqa
+        for record in caplog.records
+    )
+
+
+def test_report_json_china_on_error_no_exception_and_notify_user(capsys, monkeypatch):
+    monkeypatch.setattr(Configuration, "should_report", True)
+    monkeypatch.setattr(Configuration, "edge_kinesis_aws_access_key_id", "my_value")
+    monkeypatch.setattr(Configuration, "edge_kinesis_aws_secret_access_key", "my_value")
+    monkeypatch.setattr(boto3, "client", MagicMock(side_effect=Exception))
+    lumigo_utils.get_logger().setLevel(logging.CRITICAL)
+
+    report_json(CHINA_REGION, [{"a": "b"}])
+
+    assert "Failed to send spans" in capsys.readouterr().out
+
+
+def test_china_shouldnt_establish_http_connection(monkeypatch):
+    monkeypatch.setenv("AWS_REGION", CHINA_REGION)
+    # Reload a duplicate of lambda_reporter
+    spec = importlib.util.find_spec("lumigo_tracer.lambda_tracer.lambda_reporter")
+    lumigo_utils_reloaded = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(lumigo_utils_reloaded)
+    establish_connection()
+
+    assert lumigo_utils_reloaded.edge_connection is None
+
+
+def test_china_with_env_variable_shouldnt_reuse_boto3_connection(monkeypatch):
+    monkeypatch.setenv("LUMIGO_KINESIS_SHOULD_REUSE_CONNECTION", "false")
+    monkeypatch.setattr(Configuration, "should_report", True)
+    monkeypatch.setattr(Configuration, "edge_kinesis_aws_access_key_id", "my_value")
+    monkeypatch.setattr(Configuration, "edge_kinesis_aws_secret_access_key", "my_value")
+    monkeypatch.setattr(boto3, "client", MagicMock())
+
+    report_json(CHINA_REGION, [{"a": "b"}])
+    report_json(CHINA_REGION, [{"a": "b"}])
+
+    assert boto3.client.call_count == 2
+
+
+def test_china_reuse_boto3_connection(monkeypatch):
+    monkeypatch.setattr(Configuration, "should_report", True)
+    monkeypatch.setattr(Configuration, "edge_kinesis_aws_access_key_id", "my_value")
+    monkeypatch.setattr(Configuration, "edge_kinesis_aws_secret_access_key", "my_value")
+    monkeypatch.setattr(boto3, "client", MagicMock())
+
+    report_json(CHINA_REGION, [{"a": "b"}])
+    report_json(CHINA_REGION, [{"a": "b"}])
+
+    boto3.client.assert_called_once()

--- a/src/test/unit/lambda_tracer/test_spans_container.py
+++ b/src/test/unit/lambda_tracer/test_spans_container.py
@@ -9,9 +9,11 @@ from datetime import datetime
 
 import pytest
 
-from lumigo_tracer import lumigo_utils, add_execution_tag
+from lumigo_tracer import add_execution_tag
+from lumigo_tracer.lambda_tracer import lambda_reporter
+from lumigo_tracer.lambda_tracer.lambda_reporter import get_extension_dir
 from lumigo_tracer.wrappers.http.http_parser import HTTP_TYPE
-from lumigo_tracer.spans_container import (
+from lumigo_tracer.lambda_tracer.spans_container import (
     SpansContainer,
     TimeoutMechanism,
     FUNCTION_TYPE,
@@ -53,7 +55,7 @@ def test_spans_container_not_send_start_span_on_send_only_on_errors_mode(monkeyp
 def test_start(monkeypatch):
     lumigo_utils_mock = mock.Mock()
     monkeypatch.setenv("LUMIGO_USE_TRACER_EXTENSION", "true")
-    monkeypatch.setattr(lumigo_utils, "write_extension_file", lumigo_utils_mock)
+    monkeypatch.setattr(lambda_reporter, "write_extension_file", lumigo_utils_mock)
     monkeypatch.setattr(SpansContainer, "_generate_start_span", lambda *args, **kwargs: {"a": "a"})
     monkeypatch.setattr(Configuration, "should_report", True)
     SpansContainer().start()
@@ -95,7 +97,7 @@ def only_if_error(dummy_span, monkeypatch, tmpdir):
 
     SpansContainer.get_span().add_span(dummy_span)
     reported_ttl = SpansContainer.get_span().end({})
-    stop_path_path = f"{lumigo_utils.get_extension_dir()}/span_name_stop"
+    stop_path_path = f"{get_extension_dir()}/span_name_stop"
     return reported_ttl, stop_path_path
 
 

--- a/src/test/unit/test_lumigo_utils.py
+++ b/src/test/unit/test_lumigo_utils.py
@@ -1,24 +1,13 @@
-import importlib.util
 import inspect
 import logging
-import os
-import uuid
 from collections import OrderedDict
 from decimal import Decimal
 import datetime
-import http.client
-import socket
-from unittest.mock import Mock
-
-import boto3
-from mock import MagicMock
 
 import pytest
+
 from lumigo_tracer import lumigo_utils
 from lumigo_tracer.lumigo_utils import (
-    _create_request_body,
-    _is_span_has_error,
-    _get_event_base64_size,
     MAX_VARS_SIZE,
     format_frames,
     _truncate_locals,
@@ -35,40 +24,20 @@ from lumigo_tracer.lumigo_utils import (
     SKIP_SCRUBBING_KEYS,
     get_timeout_buffer,
     lumigo_dumps,
-    get_edge_host,
-    EDGE_PATH,
-    report_json,
     is_kill_switch_on,
     KILL_SWITCH,
     is_error_code,
     get_size_upper_bound,
     is_aws_arn,
-    CHINA_REGION,
     internal_analytics_message,
     INTERNAL_ANALYTICS_PREFIX,
-    InternalState,
     concat_old_body_to_new,
     TRUNCATE_SUFFIX,
     DEFAULT_AUTO_TAG_KEY,
     lumigo_safe_execute,
     is_python_37,
+    is_span_has_error,
 )
-import json
-
-
-@pytest.fixture
-def dummy_span():
-    return {"dummy": "dummy"}
-
-
-@pytest.fixture
-def function_end_span():
-    return {"dummy_end": "dummy_end"}
-
-
-@pytest.fixture
-def error_span():
-    return {"dummy": "dummy", "error": "Error"}
 
 
 @pytest.mark.parametrize(
@@ -81,40 +50,7 @@ def error_span():
     ],
 )
 def test_is_span_has_error(input_span, expected_is_error):
-    assert _is_span_has_error(input_span) is expected_is_error
-
-
-def test_create_request_body_default(dummy_span):
-    assert _create_request_body([dummy_span], False) == json.dumps([dummy_span])
-
-
-def test_create_request_body_not_effecting_small_events(dummy_span):
-    assert _create_request_body([dummy_span], True, 1_000_000) == json.dumps([dummy_span])
-
-
-def test_create_request_body_keep_function_span_and_filter_other_spans(
-    dummy_span, function_end_span
-):
-    expected_result = [dummy_span, dummy_span, dummy_span, function_end_span]
-    size = _get_event_base64_size(expected_result)
-    assert _create_request_body(expected_result * 2, True, size) == json.dumps(
-        [function_end_span, dummy_span, dummy_span, dummy_span]
-    )
-
-
-def test_create_request_body_take_error_first(dummy_span, error_span, function_end_span):
-    expected_result = [function_end_span, error_span, dummy_span, dummy_span]
-    input = [
-        dummy_span,
-        dummy_span,
-        dummy_span,
-        dummy_span,
-        dummy_span,
-        error_span,
-        function_end_span,
-    ]
-    size = _get_event_base64_size(expected_result)
-    assert _create_request_body(input, True, size) == json.dumps(expected_result)
+    assert is_span_has_error(input_span) is expected_is_error
 
 
 @pytest.mark.parametrize(
@@ -462,161 +398,6 @@ def test_warn_client_dont_print(capsys, monkeypatch):
 def test_get_timeout_buffer(remaining_time, conf, expected):
     Configuration.timeout_timer_buffer = conf
     assert get_timeout_buffer(remaining_time) == expected
-
-
-@pytest.mark.parametrize(
-    ["arg", "host"],
-    [("https://a.com", "a.com"), (f"https://b.com{EDGE_PATH}", "b.com"), ("h.com", "h.com")],
-)
-def test_get_edge_host(arg, host, monkeypatch):
-    monkeypatch.setattr(Configuration, "host", arg)
-    assert get_edge_host("region") == host
-
-
-def test_report_json_extension_spans_mode(monkeypatch, reporter_mock, tmpdir):
-    extension_dir = tmpdir.mkdir("tmp")
-    monkeypatch.setattr(uuid, "uuid4", lambda *args, **kwargs: "span_name")
-    monkeypatch.setattr(Configuration, "should_report", True)
-    monkeypatch.setenv("LUMIGO_USE_TRACER_EXTENSION", "TRUE")
-    monkeypatch.setenv("LUMIGO_EXTENSION_SPANS_DIR_KEY", extension_dir)
-    mocked_urandom = MagicMock(hex=MagicMock(return_value="my_mocked_data"))
-    monkeypatch.setattr(os, "urandom", lambda *args, **kwargs: mocked_urandom)
-
-    start_span = [{"span": "true"}]
-    report_json(region=None, msgs=start_span, is_start_span=True)
-
-    spans = []
-    size_factor = 100
-    for i in range(size_factor):
-        spans.append(
-            {
-                i: "a" * size_factor,
-            }
-        )
-    report_json(region=None, msgs=spans, is_start_span=False)
-    start_path_path = f"{lumigo_utils.get_extension_dir()}/span_name_span"
-    end_path_path = f"{lumigo_utils.get_extension_dir()}/span_name_end"
-    start_file_content = json.loads(open(start_path_path, "r").read())
-    end_file_content = json.loads(open(end_path_path, "r").read())
-    assert start_span == start_file_content
-    assert json.dumps(end_file_content) == json.dumps(spans)
-
-
-@pytest.mark.parametrize(
-    "errors, final_log", [(ValueError, "ERROR"), ([ValueError, Mock()], "INFO")]
-)
-def test_report_json_retry(monkeypatch, reporter_mock, caplog, errors, final_log):
-    reporter_mock.side_effect = report_json
-    monkeypatch.setattr(Configuration, "host", "force_reconnect")
-    monkeypatch.setattr(Configuration, "should_report", True)
-    monkeypatch.setattr(http.client, "HTTPSConnection", Mock())
-    http.client.HTTPSConnection("force_reconnect").getresponse.side_effect = errors
-
-    report_json(None, [{"a": "b"}])
-
-    assert caplog.records[-1].levelname == final_log
-
-
-def test_report_json_fast_failure_after_timeout(monkeypatch, reporter_mock, caplog):
-    reporter_mock.side_effect = report_json
-    monkeypatch.setattr(Configuration, "host", "host")
-    monkeypatch.setattr(Configuration, "should_report", True)
-    monkeypatch.setattr(http.client, "HTTPSConnection", Mock())
-    http.client.HTTPSConnection("force_reconnect").getresponse.side_effect = socket.timeout
-
-    assert report_json(None, [{"a": "b"}]) == 0
-    assert caplog.records[-1].msg == "Timeout while connecting to host"
-
-    assert report_json(None, [{"a": "b"}]) == 0
-    assert caplog.records[-1].msg == "Skip sending messages due to previous timeout"
-
-    InternalState.timeout_on_connection = datetime.datetime(2016, 1, 1)
-    assert report_json(None, [{"a": "b"}]) == 0
-    assert caplog.records[-1].msg == "Timeout while connecting to host"
-
-
-def test_report_json_china_missing_access_key_id(monkeypatch, reporter_mock, caplog):
-    monkeypatch.setattr(Configuration, "should_report", True)
-    reporter_mock.side_effect = report_json
-    assert report_json(CHINA_REGION, [{"a": "b"}]) == 0
-    assert any(
-        "edge_kinesis_aws_access_key_id" in record.message and record.levelname == "ERROR"
-        for record in caplog.records
-    )
-
-
-def test_report_json_china_missing_secret_access_key(monkeypatch, reporter_mock, caplog):
-    monkeypatch.setattr(Configuration, "should_report", True)
-    monkeypatch.setattr(Configuration, "edge_kinesis_aws_access_key_id", "my_value")
-    reporter_mock.side_effect = report_json
-    assert report_json(CHINA_REGION, [{"a": "b"}]) == 0
-    assert any(
-        "edge_kinesis_aws_secret_access_key" in record.message and record.levelname == "ERROR"
-        for record in caplog.records
-    )
-
-
-def test_report_json_china_no_boto(monkeypatch, reporter_mock, caplog):
-    reporter_mock.side_effect = report_json
-    monkeypatch.setattr(Configuration, "should_report", True)
-    monkeypatch.setattr(Configuration, "edge_kinesis_aws_access_key_id", "my_value")
-    monkeypatch.setattr(Configuration, "edge_kinesis_aws_secret_access_key", "my_value")
-    monkeypatch.setattr(lumigo_utils, "boto3", None)
-
-    report_json(CHINA_REGION, [{"a": "b"}])
-
-    assert any(
-        "boto3 is missing. Unable to send to Kinesis" in record.message
-        and record.levelname == "ERROR"  # noqa
-        for record in caplog.records
-    )
-
-
-def test_report_json_china_on_error_no_exception_and_notify_user(capsys, monkeypatch):
-    monkeypatch.setattr(Configuration, "should_report", True)
-    monkeypatch.setattr(Configuration, "edge_kinesis_aws_access_key_id", "my_value")
-    monkeypatch.setattr(Configuration, "edge_kinesis_aws_secret_access_key", "my_value")
-    monkeypatch.setattr(boto3, "client", MagicMock(side_effect=Exception))
-    lumigo_utils.get_logger().setLevel(logging.CRITICAL)
-
-    report_json(CHINA_REGION, [{"a": "b"}])
-
-    assert "Failed to send spans" in capsys.readouterr().out
-
-
-def test_china_shouldnt_establish_http_connection(monkeypatch):
-    monkeypatch.setenv("AWS_REGION", CHINA_REGION)
-    # Reload a duplicate of lumigo_utils
-    spec = importlib.util.find_spec("lumigo_tracer.lumigo_utils")
-    lumigo_utils_reloaded = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(lumigo_utils_reloaded)
-
-    assert lumigo_utils_reloaded.edge_connection is None
-
-
-def test_china_with_env_variable_shouldnt_reuse_boto3_connection(monkeypatch):
-    monkeypatch.setenv("LUMIGO_KINESIS_SHOULD_REUSE_CONNECTION", "false")
-    monkeypatch.setattr(Configuration, "should_report", True)
-    monkeypatch.setattr(Configuration, "edge_kinesis_aws_access_key_id", "my_value")
-    monkeypatch.setattr(Configuration, "edge_kinesis_aws_secret_access_key", "my_value")
-    monkeypatch.setattr(boto3, "client", MagicMock())
-
-    report_json(CHINA_REGION, [{"a": "b"}])
-    report_json(CHINA_REGION, [{"a": "b"}])
-
-    assert boto3.client.call_count == 2
-
-
-def test_china_reuse_boto3_connection(monkeypatch):
-    monkeypatch.setattr(Configuration, "should_report", True)
-    monkeypatch.setattr(Configuration, "edge_kinesis_aws_access_key_id", "my_value")
-    monkeypatch.setattr(Configuration, "edge_kinesis_aws_secret_access_key", "my_value")
-    monkeypatch.setattr(boto3, "client", MagicMock())
-
-    report_json(CHINA_REGION, [{"a": "b"}])
-    report_json(CHINA_REGION, [{"a": "b"}])
-
-    boto3.client.assert_called_once()
 
 
 @pytest.mark.parametrize("env, expected", [("True", True), ("other", False), ("123", False)])

--- a/src/test/unit/test_user_utils.py
+++ b/src/test/unit/test_user_utils.py
@@ -1,7 +1,7 @@
 import time
 import pytest
 
-from lumigo_tracer.spans_container import SpansContainer
+from lumigo_tracer.lambda_tracer.spans_container import SpansContainer
 from lumigo_tracer.user_utils import (
     warn,
     info,

--- a/src/test/unit/wrappers/aiohttp/test_aiohttp_wrapper.py
+++ b/src/test/unit/wrappers/aiohttp/test_aiohttp_wrapper.py
@@ -5,7 +5,7 @@ import aiohttp
 import pytest
 
 import lumigo_tracer
-from lumigo_tracer.spans_container import SpansContainer
+from lumigo_tracer.lambda_tracer.spans_container import SpansContainer
 
 
 def test_aiohttp_happy_flow(context, token):

--- a/src/test/unit/wrappers/conftest.py
+++ b/src/test/unit/wrappers/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+from lumigo_tracer.wrappers import wrap
+
+
+@pytest.fixture(autouse=True)
+def wrap_everything(aws_environment):
+    wrap()

--- a/src/test/unit/wrappers/http/test_sync_http_wrappers.py
+++ b/src/test/unit/wrappers/http/test_sync_http_wrappers.py
@@ -23,7 +23,7 @@ from lumigo_tracer.lumigo_utils import (
     TRUNCATE_SUFFIX,
 )
 from lumigo_tracer.wrappers.http.http_parser import Parser
-from lumigo_tracer.spans_container import SpansContainer
+from lumigo_tracer.lambda_tracer.spans_container import SpansContainer
 from lumigo_tracer.wrappers.http.http_data_classes import HttpRequest
 from lumigo_tracer.wrappers.http.sync_http_wrappers import (
     add_request_event,

--- a/src/test/unit/wrappers/http/test_sync_http_wrappers_threads.py
+++ b/src/test/unit/wrappers/http/test_sync_http_wrappers_threads.py
@@ -6,7 +6,7 @@ import concurrent.futures
 import json
 
 import lumigo_tracer
-from lumigo_tracer.spans_container import SpansContainer
+from lumigo_tracer.lambda_tracer.spans_container import SpansContainer
 
 COUNT = 5
 

--- a/src/test/unit/wrappers/pymongo/test_pymongo_wrapper.py
+++ b/src/test/unit/wrappers/pymongo/test_pymongo_wrapper.py
@@ -2,7 +2,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from lumigo_tracer.spans_container import SpansContainer
+from lumigo_tracer.lambda_tracer.spans_container import SpansContainer
 from lumigo_tracer.wrappers.pymongo.pymongo_wrapper import LumigoMongoMonitoring
 
 

--- a/src/test/unit/wrappers/redis/test_redis_wrapper.py
+++ b/src/test/unit/wrappers/redis/test_redis_wrapper.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from lumigo_tracer.spans_container import SpansContainer
+from lumigo_tracer.lambda_tracer.spans_container import SpansContainer
 from lumigo_tracer.wrappers.redis.redis_wrapper import execute_command_wrapper, execute_wrapper
 
 FUNCTION_RESULT = "Result"

--- a/src/test/unit/wrappers/sql/test_sqlalchemy_wrapper.py
+++ b/src/test/unit/wrappers/sql/test_sqlalchemy_wrapper.py
@@ -7,8 +7,8 @@ from sqlalchemy import create_engine, Table, Column, Integer, String, MetaData
 from sqlalchemy.sql import select
 
 from lumigo_tracer.lumigo_utils import DEFAULT_MAX_ENTRY_SIZE
-from lumigo_tracer.spans_container import SpansContainer
-from lumigo_tracer.tracer import lumigo_tracer
+from lumigo_tracer.lambda_tracer.spans_container import SpansContainer
+from lumigo_tracer.lambda_tracer.tracer import lumigo_tracer
 
 TOKEN = "t_10faa5e13e7844aaa1234"
 


### PR DESCRIPTION
Move the tracer-specific logic into a well-marked module and don't run code in global time if not lambda.
* Created `global_scope_exec` to execute all the code in global time (only for lambda environments)
* Refactor the reporter logic from the general utils to its specific module
* All the global time code is now executed from the `__init__` of the package instead of per-module