### PR TITLE
TRAC-3-Support-large-invocations-zip-in-Python-tracer

### DIFF
--- a/src/lumigo_tracer/lambda_tracer/lambda_reporter.py
+++ b/src/lumigo_tracer/lambda_tracer/lambda_reporter.py
@@ -179,6 +179,7 @@ def report_json(
             raise ValueError("Connection is not established")
 
         try:
+            get_logger().debug(f"Sending data to {host}/{EDGE_PATH}: {data}")
             edge_connection.request(
                 "POST",
                 EDGE_PATH,
@@ -570,7 +571,7 @@ def _split_and_zip_spans(spans: List[Dict[Any, Any]]) -> List[str]:
         end_index = i + MAX_SPANS_BULK_SIZE
         bulk = spans[start_index:end_index]
         zipped_spans = b64encode(gzip.compress(aws_dump(bulk).encode("utf-8"))).decode("utf-8")
-        spans_bulks.append(zipped_spans)
+        spans_bulks.append(aws_dump(zipped_spans))
     return spans_bulks
 
 

--- a/src/lumigo_tracer/lambda_tracer/lambda_reporter.py
+++ b/src/lumigo_tracer/lambda_tracer/lambda_reporter.py
@@ -170,8 +170,8 @@ def report_json(
     try:
         start_time = time.time()
 
-        get_logger().debug(f"Going to send {len(to_send)} spans...")
         to_send_list: List[str] = to_send if isinstance(to_send, list) else [to_send]
+        get_logger().debug(f"Going to send a list of {len(to_send_list)} spans...")
         # Process each span one by one
         for span_data in to_send_list:
             send_single_span(host, span_data)

--- a/src/lumigo_tracer/lambda_tracer/lambda_reporter.py
+++ b/src/lumigo_tracer/lambda_tracer/lambda_reporter.py
@@ -170,10 +170,10 @@ def report_json(
     try:
         start_time = time.time()
 
-        to_send_list: List[str] = to_send if isinstance(to_send, list) else [to_send]
-        get_logger().debug(f"Going to send a list of {len(to_send_list)} spans...")
+        to_send = to_send if isinstance(to_send, list) else [to_send]
+        get_logger().debug(f"Going to send a list of {len(to_send)} spans...")
         # Process each span one by one
-        for span_data in to_send_list:
+        for span_data in to_send:
             send_single_span(host, span_data)
 
         duration = int((time.time() - start_time) * 1000)

--- a/src/lumigo_tracer/lambda_tracer/lambda_reporter.py
+++ b/src/lumigo_tracer/lambda_tracer/lambda_reporter.py
@@ -148,7 +148,7 @@ def report_json(
     try:
         prune_trace: bool = not os.environ.get("LUMIGO_PRUNE_TRACE_OFF", "").lower() == "true"
         should_try_zip: bool = _should_try_zip()
-        to_send: str | List[str] = _create_request_body(msgs, prune_trace, should_try_zip)
+        to_send: Union[str, List[str]] = _create_request_body(msgs, prune_trace, should_try_zip)
     except Exception as e:
         get_logger().exception("Failed to create request: A span was lost.", exc_info=e)
         return 0
@@ -409,7 +409,7 @@ def _create_request_body(
     max_size: int = MAX_SIZE_FOR_REQUEST,
     max_error_size: int = MAX_SIZE_FOR_REQUEST_ON_ERROR,
     too_big_spans_threshold: int = TOO_BIG_SPANS_THRESHOLD,
-) -> str | List[str]:
+) -> Union[str, List[str]]:
     """
     This function creates the request body from the given spans.
     If there is an error we limit the size of the request to max_error_size otherwise to max_size.

--- a/src/lumigo_tracer/lambda_tracer/lambda_reporter.py
+++ b/src/lumigo_tracer/lambda_tracer/lambda_reporter.py
@@ -195,7 +195,6 @@ def send_single_span(host: str, data: str, retry: bool = True) -> None:
         raise ValueError("Connection is not established")
 
     try:
-        get_logger().debug(f"Sending data to {host}/{EDGE_PATH}: {data}")
         edge_connection.request(
             "POST",
             EDGE_PATH,

--- a/src/lumigo_tracer/lambda_tracer/lambda_reporter.py
+++ b/src/lumigo_tracer/lambda_tracer/lambda_reporter.py
@@ -125,7 +125,6 @@ def get_edge_host(region: Optional[str] = None) -> str:
 def report_json(
     region: Optional[str],
     msgs: List[Dict[Any, Any]],
-    should_retry: bool = True,
     is_start_span: bool = False,
 ) -> int:
     """
@@ -133,7 +132,6 @@ def report_json(
 
     :param region: The region to use as default if not configured otherwise.
     :param msgs: the message to send.
-    :param should_retry: False to disable the default retry on unsuccessful sending
     :param is_start_span: a flag to indicate if this is the start_span
      of spans that will be written
     :return: The duration of reporting (in milliseconds),

--- a/src/test/conftest.py
+++ b/src/test/conftest.py
@@ -1,4 +1,6 @@
+import base64
 import builtins
+import gzip
 import logging
 import os
 import shutil
@@ -134,3 +136,22 @@ def lambda_traced(monkeypatch, aws_environment):
 @pytest.fixture
 def wrap_all_libraries(lambda_traced):
     wrappers.wrap()
+
+
+@pytest.fixture
+def unzip_zipped_spans():
+    """
+    Pytest fixture that provides a function to unzip and decode zipped spans.
+    """
+
+    def _unzip(zipped_spans: str) -> str:
+        # Step 1: Decode the base64 encoded string back to bytes
+        compressed_data = base64.b64decode(zipped_spans)
+
+        # Step 2: Decompress the gzip data
+        decompressed_data = gzip.decompress(compressed_data)
+
+        # Step 3: Decode the bytes back to a string
+        return decompressed_data.decode("utf-8")
+
+    return _unzip

--- a/src/test/unit/lambda_tracer/test_lambda_reporter.py
+++ b/src/test/unit/lambda_tracer/test_lambda_reporter.py
@@ -652,8 +652,9 @@ def test_split_and_zip_spans_successfully():
     # Test unzipping and verify that it equals the original spans
     unzipped_spans = []
     for zipped_span in zipped_spans_bulks:
+        zipped_span_unload = json.loads(zipped_span)
         # Decode base64 and unzip
-        unzipped = gzip.decompress(b64decode(zipped_span)).decode("utf-8")
+        unzipped: str = gzip.decompress(b64decode(zipped_span_unload)).decode("utf-8")
         unzipped_spans.extend(json.loads(unzipped))
 
     # Check that unzipped spans match the original spans

--- a/src/test/unit/lambda_tracer/test_tracer.py
+++ b/src/test/unit/lambda_tracer/test_tracer.py
@@ -128,7 +128,7 @@ def test_lambda_wrapper_exception(exc, context):
     assert "reporter_rtt" in function_span
     assert "maxFinishTime" not in function_span
     # Test that we can create an output message out of this span
-    assert _create_request_body([function_span], prune_size_flag=False)
+    assert _create_request_body([function_span], prune_size_flag=False, should_try_zip=False)
 
 
 def test_lambda_wrapper_return_decimal(context):
@@ -405,7 +405,7 @@ def test_omitting_keys(wrap_all_libraries, context):
     assert span.function_span["return_value"] == '{"secret_password": "****"}'
     assert span.function_span["event"] == '{"key": "****"}'
     http_spans = list(SpansContainer.get_span().spans.values())
-    spans = json.loads(_create_request_body(http_spans, True))
+    spans = json.loads(_create_request_body(http_spans, True, False))
     assert spans[0]["info"]["httpInfo"]["request"]["body"] == json.dumps(
         {"a": "b", "myPassword": "****"}
     )

--- a/src/test/unit/lambda_tracer/test_tracer.py
+++ b/src/test/unit/lambda_tracer/test_tracer.py
@@ -128,7 +128,7 @@ def test_lambda_wrapper_exception(exc, context):
     assert "reporter_rtt" in function_span
     assert "maxFinishTime" not in function_span
     # Test that we can create an output message out of this span
-    assert _create_request_body([function_span], prune_size_flag=False, should_try_zip=False)
+    assert _create_request_body(None, [function_span], prune_size_flag=False, should_try_zip=False)
 
 
 def test_lambda_wrapper_return_decimal(context):
@@ -405,7 +405,7 @@ def test_omitting_keys(wrap_all_libraries, context):
     assert span.function_span["return_value"] == '{"secret_password": "****"}'
     assert span.function_span["event"] == '{"key": "****"}'
     http_spans = list(SpansContainer.get_span().spans.values())
-    spans = json.loads(_create_request_body(http_spans, True, False))
+    spans = json.loads(_create_request_body(None, http_spans, True, False))
     assert spans[0]["info"]["httpInfo"]["request"]["body"] == json.dumps(
         {"a": "b", "myPassword": "****"}
     )


### PR DESCRIPTION
## Description:
Adding support for spans zipping for the Python tracer. Reaching the size limits, the tracer should try to zip spans first, before dropping/prioritizing them

## Jira Ticket:
See [TRAC-3](https://lumigo.atlassian.net/browse/TRAC-3)

[TRAC-3]: https://lumigo.atlassian.net/browse/TRAC-3?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ